### PR TITLE
Update download-ontology.md

### DIFF
--- a/docs/_docs/download-ontology.md
+++ b/docs/_docs/download-ontology.md
@@ -4,7 +4,7 @@ permalink: /docs/download-ontology/
 ---
 ## Currently available
 
-This page describes the various versions of Gene Ontology available for download. To save, right-click (or ctrl-click on Mac) on the file link and then "save as" to your computer. OBO files are human-readable (in addition to machine-readable) and can be opened in any text editor. OWL files can be opened with [Protégé](https://protege.stanford.edu/)
+This page describes the various versions of Gene Ontology available for download. To save, right-click (or ctrl-click on Mac) on the file link and then "save as" to your computer. OBO files are human-readable (in addition to machine-readable) and can be opened in any text editor. OWL files can be opened with [Protégé](https://protege.stanford.edu/).
 
 |Name 	|Permanent URL |	Description|
 |-------|--------------|-------------|
@@ -30,17 +30,13 @@ GO slims are subsets of terms in the ontology. GO slims give a broad overview of
 GO classes have been mapped to a number of other, external, classification systems. [Click here](http://geneontology.org/page/download-mappings) to view and download these mappings.
 ## Legacy Downloads
 
-The GO is also available in a number of other formats. These other formats are not recommended for new applications, but as many existing applications rely on these downloads we will continue to support them. For users of the GO-RDF/XML version of the ontology, we recommend the OWL RDF/XML version (see above). For OWL users, we continue to support the legacy obo2owl translation, but users are strongly encouraged to switch to the new translation (see above).
+The GO is also available in other formats. These other formats are not recommended for new applications, but as many existing applications rely on these downloads we will continue to support them. For users of the GO-RDF/XML version of the ontology, we recommend the OWL RDF/XML version (see above). For OWL users, we continue to support the legacy obo2owl translation, but users are strongly encouraged to switch to the new translation (see above).
 
-|Database tables |   | | |
+|**XML format** Database tables |   | | |
 |----------------|---|---|---|
-|MySQL database dump [database schema] |	Filtered ontology |	Daily |	MySQL database dump|
-|SQL database dump [database schema] |	Filtered ontology |	Daily |	SQL database dump|
-|**XML format**||||
-|RDF-XML [format guide] |	Filtered ontology |	Daily |	rdf-xml.gz|
 |OBO-XML [format guide; OBO-XML RNC; OBO-XML RNG] |	Filtered ontology |	Daily |	obo-xml.gz|
 |OWL (old mapping) [format guide] |	Filtered ontology |	Daily |	owl.gz|
 
 ### Archives and previous versions
 
-An archive of the ontology files (in both current and legacy formats) from the first of each month is available on the GO website at ftp://ftp.geneontology.org/go/ontology-archive/.
+An archive of the ontology files from the first of each month is available on the GO website at ftp://ftp.geneontology.org/go/ontology-archive/.


### PR DESCRIPTION
I tried to remove references to CVS. Please verify this is accurate now, and not too much/too little was removed.

The Legacy downloads  ( http://geneontology.org/page/download-ontology) section indicates we're updating the SQL dumps daily. Are we continuing this? I removed all pages about SQL elsewhere. Could @kltm confirm the status of the Legacy downloads and if I removed too much?

Thanks