### PR TITLE
Update download-go-annotations.md

### DIFF
--- a/_docs/download-go-annotations.md
+++ b/_docs/download-go-annotations.md
@@ -9,17 +9,16 @@ redirect_from:
 
 # Download annotations 
 
-## GO annotation formats
-+ Released monthly
-+ Taxon-specific
-+ Available formats:
-  + [GAF format](/docs/go-annotation-file-gaf-format-2.1/)
-  + [GPAD](/docs/gene-product-association-data-gpad-format/) + [GPI](/docs/gene-product-information-gpi-format/)
-  
-## GO annotation download links
-GAF files by species can be browsed and obtained from the [GAF download page](http://current.geneontology.org/products/pages/downloads.html)
+GAF files by species can be found at [GAF download page](http://current.geneontology.org/products/pages/downloads.html)
 
-GAF, GPAD and GPI files are also available from the [/annotations/](http://current.geneontology.org/annotations/index.html){:target="blank"} of the current release on [http://current.geneontology.org](http://current.geneontology.org){:target="blank"}
+GAF, GPAD and GPI files are also available from the [/annotations/](http://current.geneontology.org/annotations/index.html){:target="blank"} directory of the current release: [http://current.geneontology.org](http://current.geneontology.org){:target="blank"}
+
+## Annotation files: General information
++ Released monthly
++ Taxon-specific, although some files contain multiple taxons
++ File format guides:
+  + [GAF](/docs/go-annotation-file-gaf-format-2.1/): GO Annotation Files are tab-delimited text files that are human-friendly (in addition to machine-readable)
+  + [GPAD](/docs/gene-product-association-data-gpad-format/) + [GPI](/docs/gene-product-information-gpi-format/) companion files: Gene Product Association Data (GPAD) files are intended to work in conjunction with a Gene Product Information (GPI) file
 
 ## Programmatic access to GO annotations
 As for any resource in GO, GO annotations are accessible through the DOI-versioned release stored in [Zenodo](https://doi.org/10.5281/zenodo.1205159){:target="blank"} and can be retrieved using BDBag. Read more about [programmatic access](/docs/tools-guide/#programmatic-download-bdbag).

--- a/_docs/download-go-annotations.md
+++ b/_docs/download-go-annotations.md
@@ -13,9 +13,10 @@ GAF files by species can be found at [GAF download page](http://current.geneonto
 
 GAF, GPAD and GPI files are also available from the [/annotations/](http://current.geneontology.org/annotations/index.html){:target="blank"} directory of the current release: [http://current.geneontology.org](http://current.geneontology.org){:target="blank"}
 
+Downloading annotations by specific taxon is possible through [AmiGO](http://amigo.geneontology.org/amigo/search/annotation)
+
 ## Annotation files: General information
 + Released monthly
-+ Taxon-specific, although some files contain multiple taxons
 + File format guides:
   + [GAF](/docs/go-annotation-file-gaf-format-2.1/): GO Annotation Files are tab-delimited text files that are human-friendly (in addition to machine-readable)
   + [GPAD](/docs/gene-product-association-data-gpad-format/) + [GPI](/docs/gene-product-information-gpi-format/) companion files: Gene Product Association Data (GPAD) files are intended to work in conjunction with a Gene Product Information (GPI) file


### PR DESCRIPTION
Make download links more visible on page. Adding a bit more language to split guides from actual download links.

Would ideally like this to be really similar to formatting/language on the Ontology downloads page (pr in progress that's slightly different from this)