### PR TITLE
Update faq.md

### DIFF
--- a/_docs/faq.md
+++ b/_docs/faq.md
@@ -722,13 +722,17 @@ FAQ tags: 
 [ontology](/faq-tags/ontology)
 {:/comment}
 
-You can find the number of terms on each of the ontologies by going to [AmiGO](http://amigo.geneontology.org/){:target="blank"}:
+You can find the number of terms on each of the ontologies on the geneontology.org home page: there is a ['see statistics'](http://geneontology.org/stats.html) link on the upper right.
+
+Current release statistics are also available on [AmiGO](http://amigo.geneontology.org/){:target="blank"}:
 
 Under the 'Advanced Search' section in the middle of the page, use the drop-down menu to choose "Ontology". You don't need to type anything on the 'Quick search' box.
-This action will send you to the ['Information about Ontology search'](http://amigo.geneontology.org/amigo/search/ontology){:target="blank"} page. There, open the 'Ontology source' filter menu on the left. As of January 2019, the number of terms on per ontology were:
--   29,687 Biological process
--   11,110 Molecular Function
--   4,206 Celular component
+This action will send you to the ['Information about Ontology search'](http://amigo.geneontology.org/amigo/search/ontology){:target="blank"} page. There, open the 'Ontology source' filter menu on the left. As of January 2020, the number of terms on per ontology were:
+-   29,393 Biological process
+-   11,123 Molecular Function
+-   4,184 Celular component
+
+Please note the number of terms changes between releases: new terms are created, existing terms may be merged, and some terms are obsoleted to reflect the current understanding of biology. This is why it is essential to provide a release version when citing the GO.
 
 If you need a reference for this information, refer to our [citation policy and license](/docs/go-citation-policy/). 
 


### PR DESCRIPTION
All changes under "Where can I find the number of terms in each of the ontologies?" 

Added that stats are available on homepage. Updated term counts from jan 2019 to jan 2020.  Added tiny bit to stress #s change and to beg users to cite GO by version.