### PR TITLE
GA to be on default layout rather than index.html

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html>
 
+<!-- Google Analytics: Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-440742-2"></script>
+<script>
+	window.dataLayer = window.dataLayer || [];
+	function gtag() { dataLayer.push(arguments); }
+	gtag('js', new Date());
+	gtag('config', 'UA-440742-2');
+</script>
+
+
 {% include head.html %}
 
 <body>

--- a/index.html
+++ b/index.html
@@ -3,17 +3,6 @@ layout: default
 ---
 
 
-<!-- Google Analytics: Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-440742-2"></script>
-<script>
-	window.dataLayer = window.dataLayer || [];
-	function gtag() { dataLayer.push(arguments); }
-	gtag('js', new Date());
-	gtag('config', 'UA-440742-2');
-</script>
-
-
-
 <div class="header-container jumbotron" style="
 		padding-bottom: 10px;
 		background-image: linear-gradient(to right, rgba(0, 23, 79, 1), rgba(0, 23, 79, 0.8), rgba(0, 23, 79, 0.5)), url(./assets/gene.jpeg);


### PR DESCRIPTION
Currently google analytics was only on the index page; this should cover more pages in the site.