### PR TITLE
Update go-annotation-file-gaf-format-22.md

### DIFF
--- a/_docs/go-annotation-file-gaf-format-22.md
+++ b/_docs/go-annotation-file-gaf-format-22.md
@@ -269,7 +269,7 @@ Contains cross references to other ontologies that can be used to qualify or enh
 
 Targets of certain processes or functions can also be included in this field to indicate the gene, gene product, or chemical involved; for example, if a gene product is annotated to protein kinase activity, the annotation extension column would contain the UniProtKB protein ID for the protein phosphorylated in the reaction.
 
-The pipe (\|) specifies an independent statement (OR) and is equivalent to making separate annotations, i.e. not all conditions are required to infer the annotated GO term. The comma (,) specifies a connected statement (AND) and indicates that all conditions are required to infer the annotated GO term. In this case, 'OR' is a weaker statement than 'AND', therefore will be correct in all cases. Pipe and comma separators may be used together in the same **With/From** field.
+The pipe (\|) specifies an independent statement (OR) and is equivalent to making separate annotations, i.e. not all conditions are required to infer the annotated GO term. The comma (,) specifies a connected statement (AND) and indicates that all conditions are required to infer the annotated GO term. In this case, 'OR' is a weaker statement than 'AND', therefore will be correct in all cases. Pipe and comma separators may be used together in the same **Annotation Extension** field.
 
 See the documentation on using the **Annotation Extension** column for details of practical usage; a wider discussion of the annotation extension column can be found on the <a href="http://wiki.geneontology.org/index.php/Annotation_Extension">GO internal documentation site</a>.
 

--- a/_docs/go-annotation-file-gaf-format-22.md
+++ b/_docs/go-annotation-file-gaf-format-22.md
@@ -175,12 +175,10 @@ Some permitted values are:
         RNAcentral:RNAcentral_id
         more...
 
-Cardinality = 0 is not allowed for ISS annotations made after October 1, 2006.
-
 Multiple entries are allowed in the **With/From** field of certain evidence codes (see below) and they must be separated with a pipe or a comma. The pipe (\|) specifies an independent statement (OR) and is equivalent to making separate annotations, i.e. not all conditions are required to infer the annotated GO term. The comma (,) specifies a connected statement (AND) and indicates that all conditions are required to infer the annotated GO term. In this case, 'OR' is a weaker statement than 'AND', therefore will be correct in all cases. Pipe and comma separators may be used together in the same **With/From** field.
 
-    This field is not mandatory overall, but is required for some evidence codes (see below or evidence code documentation);
-    cardinality 0, 1, >1; for cardinality >1 use a pipe or comma to separate entries depending on the data (examples below).
+    This field is required for some evidence codes (see below or evidence code documentation);
+    cardinality 0, 1, >1.
 
 The **With/From** field may be populated with multiple identifiers when making annotations using the following evidence codes: IMP, IGI, IPI, IC, ISS, ISA, ISO, ISM, IGC, IBA, IKR, RCA, IEA.
 
@@ -273,7 +271,7 @@ The pipe (\|) specifies an independent statement (OR) and is equivalent to makin
 
 See the documentation on using the **Annotation Extension** column for details of practical usage; a wider discussion of the annotation extension column can be found on the <a href="http://wiki.geneontology.org/index.php/Annotation_Extension">GO internal documentation site</a>.
 
-    This field is optional, cardinality 0, 1, >1; for cardinality >1 use a pipe or comma to separate entries depending on the data.
+    This field is optional, cardinality 0, 1, >1.
 
 
 #### Gene Product Form ID (column 17)

--- a/_docs/go-annotation-file-gaf-format-22.md
+++ b/_docs/go-annotation-file-gaf-format-22.md
@@ -269,9 +269,11 @@ Contains cross references to other ontologies that can be used to qualify or enh
 
 Targets of certain processes or functions can also be included in this field to indicate the gene, gene product, or chemical involved; for example, if a gene product is annotated to protein kinase activity, the annotation extension column would contain the UniProtKB protein ID for the protein phosphorylated in the reaction.
 
+The pipe (\|) specifies an independent statement (OR) and is equivalent to making separate annotations, i.e. not all conditions are required to infer the annotated GO term. The comma (,) specifies a connected statement (AND) and indicates that all conditions are required to infer the annotated GO term. In this case, 'OR' is a weaker statement than 'AND', therefore will be correct in all cases. Pipe and comma separators may be used together in the same **With/From** field.
+
 See the documentation on using the **Annotation Extension** column for details of practical usage; a wider discussion of the annotation extension column can be found on the <a href="http://wiki.geneontology.org/index.php/Annotation_Extension">GO internal documentation site</a>.
 
-    This field is optional, cardinality 0 or greater.
+    This field is optional, cardinality 0, 1, >1; for cardinality >1 use a pipe or comma to separate entries depending on the data.
 
 
 #### Gene Product Form ID (column 17)


### PR DESCRIPTION
Clarifying pipe/comma usage for column 16 as questioned in https://github.com/geneontology/helpdesk/issues/299
Changing language of cardinality specs on col 16 to be consistent with rest of doc

@pgaudet @vanaukenk if this looks correct/clear I'll change on the GAF 2.1 as well.