### PR TITLE
Update literature.md

### DIFF
--- a/_docs/literature.md
+++ b/_docs/literature.md
@@ -8,9 +8,9 @@ redirect_from:
 
 # The Gene Ontology and the scientific literature
 
-GO annotations are fundamentally based on the scientific literature. Every individual assertion in the Gene Ontology knowledgebase cites the original information justifying that assertion, and the core of these annotations are those determined through direct experimentation. Currently, the GO includes experimental findings from over [160,000 published papers](https://www.ncbi.nlm.nih.gov/pubmed/?term=loprovGeneOntol[SB]){:target="blank"}, represented as over 875,000 experimentally-supported annotations. These provide the central dataset for additional inference of over 6 million functional annotations for a diverse set of organisms spanning the tree of life.
+GO annotations are fundamentally based on the scientific literature. Every individual assertion in the Gene Ontology knowledgebase cites the original information justifying that assertion, and the core of these annotations are those determined through direct experimentation. Currently, the GO includes experimental findings from over [160,000 published papers](http://geneontology.org/stats.html){:target="blank"}, represented as over 875,000 experimentally-supported annotations. These provide the central dataset for additional inference of over 6 million functional annotations for a diverse set of organisms spanning the tree of life.
 
-Reciprocally, the GO resource plays a critical role in furthering biomedical research. GO is referenced in tens of thousands of scientific papers. The major uses of the GO, and links to the associated publications, are listed below:
+Reciprocally, the GO resource plays a critical role in furthering biomedical research. GO is referenced in over [150,000 scientific papers](https://www.ncbi.nlm.nih.gov/pubmed/?term=loprovGeneOntol[SB]){:target="blank"}. The major uses of the GO, and links to the associated publications, are listed below:
 
 * [mRNA expression data analysis](https://europepmc.org/search?query=(%22gene%20ontology%22%20AND%20(ABSTRACT%3A%22gene%20expression%22%20OR%20ABSTRACT%3A%22profiling%22%20NOT%20ABSTRACT%3A%22proteomics%22%20OR%20ABSTRACT%3A%22rna-seq%22%20OR%20ABSTRACT%3A%22rna%20expression%22%20OR%20ABSTRACT%3A%22microrna%22%20NOT%20ABSTRACT%3A%22genome-wide%20association%22%20OR%20ABSTRACT%3A%22microarray%22%20NOT%20ABSTRACT%3A%22methylation%22%20OR%20ABSTRACT%3A%22transcriptome%22))){:target="blank"}
 
@@ -24,4 +24,4 @@ Reciprocally, the GO resource plays a critical role in furthering biomedical res
 
 # History of the GO publications
 
-One of the GO's earliest documents, [On the representation of "gene function" in databases](https://zenodo.org/record/5504413), was written by Michael Ashburner in 1998. The GO Consortium regularly publishes updates and developments [as the Gene Ontology Consortium](https://pubmed.ncbi.nlm.nih.gov/?term=Gene+Ontology+Consortium%5BCorporate+Author%5D).
+One of the GO's earliest documents, [On the representation of "gene function" in databases](https://zenodo.org/record/5504413), was written by Michael Ashburner in 1998. GO's first publication was [Gene ontology: tool for the unification of biology](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3037419/){:target="blank"}.  The GO Consortium regularly publishes updates and developments [as the Gene Ontology Consortium](https://pubmed.ncbi.nlm.nih.gov/?term=Gene+Ontology+Consortium%5BCorporate+Author%5D).  For the most recent publications, please see [our citation policy](http://geneontology.org/docs/go-citation-policy/).

--- a/_docs/literature.md
+++ b/_docs/literature.md
@@ -8,7 +8,7 @@ redirect_from:
 
 # The Gene Ontology and the scientific literature
 
-GO annotations are fundamentally based on the scientific literature. Every individual assertion in the Gene Ontology knowledgebase cites the original information justifying that assertion, and the core of these annotations are those determined through direct experimentation. Currently, the GO includes experimental findings from over [140,000 published papers](https://www.ncbi.nlm.nih.gov/pubmed/?term=loprovGeneOntol[SB]){:target="blank"}, represented as over 600,000 experimentally-supported annotations. These provide the central dataset for additional inference of over 6 million functional annotations for a diverse set of organisms spanning the tree of life.
+GO annotations are fundamentally based on the scientific literature. Every individual assertion in the Gene Ontology knowledgebase cites the original information justifying that assertion, and the core of these annotations are those determined through direct experimentation. Currently, the GO includes experimental findings from over [160,000 published papers](https://www.ncbi.nlm.nih.gov/pubmed/?term=loprovGeneOntol[SB]){:target="blank"}, represented as over 875,000 experimentally-supported annotations. These provide the central dataset for additional inference of over 6 million functional annotations for a diverse set of organisms spanning the tree of life.
 
 Reciprocally, the GO resource plays a critical role in furthering biomedical research. GO is referenced in tens of thousands of scientific papers. The major uses of the GO, and links to the associated publications, are listed below:
 
@@ -21,3 +21,7 @@ Reciprocally, the GO resource plays a critical role in furthering biomedical res
 * [DNA methylation data analysis](https://europepmc.org/search?query=%22gene%20ontology%22%20AND%20ABSTRACT%3A%22methylation%22%20){:target="blank"}
 
 * [Other uses, primarily in computational biology and biomedical informatics literature](https://europepmc.org/search?query=(%22gene%20ontology%22%20NOT%20ABSTRACT%3A%22gene%20expression%22%20NOT%20ABSTRACT%3A%22profiling%22%20NOT%20ABSTRACT%3A%22proteomics%22%20NOT%20ABSTRACT%3A%22rna-seq%22%20NOT%20ABSTRACT%3A%22rna%20expression%22%20NOT%20ABSTRACT%3A%22microrna%22%20NOT%20ABSTRACT%3A%22genome-wide%20association%22%20NOT%20ABSTRACT%3A%22microarray%22%20NOT%20ABSTRACT%3A%22methylation%22%20NOT%20ABSTRACT%3A%22transcriptome%22)){:target="blank"}
+
+# History of the GO publications
+
+One of the GO's earliest documents, [On the representation of "gene function" in databases](https://zenodo.org/record/5504413), was written by Michael Ashburner in 1998. The GO Consortium regularly publishes updates and developments [as the Gene Ontology Consortium](https://pubmed.ncbi.nlm.nih.gov/?term=Gene+Ontology+Consortium%5BCorporate+Author%5D).


### PR DESCRIPTION
I'm assuming the stats for 
 experimental findings from over [160,000 published papers]
and 
 represented as over 875,000 experimentally-supported annotation

are from the stats? In which case I don't think (https://www.ncbi.nlm.nih.gov/pubmed/?term=loprovGeneOntol[SB]) is in the right place, maybe that number needs to be near `GO is referenced in tens of thousands of scientific papers.`


New section to add on the white paper link.  Is there another link of all go-written papers I can add on?