### PR TITLE
Update docs.yml

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -1,7 +1,7 @@
 
 - title: About
   docs:
-  - introduction-to-go-resource
+  - introduction-to-go
   - whoweare
   - collaborations
   - annotation-contributors


### PR DESCRIPTION
corollary to https://github.com/geneontology/geneontology.github.io/pull/387

it seems the intro-to-go-~~resource~~ menu item is not on the live website currently, is this the fix?