### PR TITLE
Fix broken link

### DIFF
--- a/_docs/go-annotation-file-gaf-format-22.md
+++ b/_docs/go-annotation-file-gaf-format-22.md
@@ -87,7 +87,7 @@ The annotation flat file format is comprised of 17 tab-delimited fields.
 #### DB (column 1)
 Refers to the database from which the identifier in **DB object ID** (column 2) is drawn. This is not necessarily the group submitting the file. If a UniProtKB ID is the **DB object ID** (column 2), **DB** (column 1) should be UniProtKB.
 
-Must be one of the values from the set of [GO database cross-references]([http://amigo.geneontology.org/xrefs](https://github.com/geneontology/go-site/blob/master/metadata/db-xrefs.yaml)).
+Must be one of the values from the set of [GO database cross-references](http://amigo.geneontology.org/xrefs).
 
     This field is mandatory, cardinality 1.
 


### PR DESCRIPTION
Fix a broken link on the documentation of the GO Annotation File v2.2 (https://geneontology.org/docs/go-annotation-file-gaf-format-2.2/)