### PR TITLE
Add GitHub Actions workflow for Jekyll site build and deploy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,55 @@
+name: Deploy Jekyll site to Pages
+
+on:
+  push:
+    branches: ["master"]
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.7'
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v4
+      - name: Fetch GO_REFs
+        run: make _data/gorefs.yaml
+      - name: Build with Jekyll
+        # Outputs to the './_site' directory by default
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+      - name: Upload artifact
+        # Automatically uploads an artifact from the './_site' directory by default
+        uses: actions/upload-pages-artifact@v3
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/_config.yml
+++ b/_config.yml
@@ -31,6 +31,7 @@ exclude:
   - .idea/
   - .gitignore
   - README.md
+  - vendor  # In GitHub workflows, the ruby/setup-ruby action will install gems here
 timezone: America/Los_Angeles
 defaults:
 

--- a/_docs/taxon-constraints.md
+++ b/_docs/taxon-constraints.md
@@ -2,7 +2,7 @@
 title: Taxon constraints in the Gene Ontology
 permalink: /docs/taxon-constraints/
 redirect_from: 
-- /cgi-bin/references.cgi#GO_REF:0000056
+- /cgi-bin/references.cgi
 ---
 
 # Taxon constraints in the Gene Ontology


### PR DESCRIPTION
Fixes #507

### Summary

* Add a GitHub Actions workflow (`.github/workflows/deploy.yaml`) which fetches the latest GO REF data (`make _data/gorefs.yaml`) and then builds and deploys the Jekyll site. 
* Add the `vendor` directory which is created by the `ruby/setup-ruby` action (https://github.com/ruby/setup-ruby?tab=readme-ov-file#bundle-config) to the `exclude` list in the Jekyll config.
* Remove a URL hash from the `redirect_from` in `_docs/taxon-constraints.md`. I don't really understand how this was working before in the automatic Jekyll build provided by GitHub Pages. This hash caused the build to fail for me locally as well as when I tested this deployment in a fork: https://github.com/pkalita-lbl/geneontology.github.io/actions/runs/8302393139/job/22724573998#step:6:373

### Comments

Just before merging this we will need to update this repo's settings to change the GitHub Pages build and deploy source to GitHub Actions. I don't have permission to make that change in this repo. Maybe @kltm can do it. Here's a screenshot of the correct setting in my test fork:

![image](https://github.com/geneontology/geneontology.github.io/assets/102547565/f4ec8130-c577-42eb-977b-3837ba770670)
