### PR TITLE
Allow deploy.yaml workflow to run on workflow_dispatch trigger

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,6 +1,9 @@
 name: Deploy Jekyll site to Pages
 
 on:
+  # Allow the workflow to be triggered manually. In particular, this allows it to be triggered
+  # from a workflow in the go-site repository.
+  workflow_dispatch:
   push:
     branches: ["master"]
 


### PR DESCRIPTION
Part of https://github.com/geneontology/go-site/issues/2235