### PR TITLE
Update docs.yml

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -23,9 +23,6 @@
 
 - title: Downloads
   docs:
-  - downloads
   - download-ontology
   - download-go-annotations
   - download-go-cams
-  - go-archives
-  - deprecated-products-and-formats


### PR DESCRIPTION
taking out the download overview page. archives and deprecated formats are being combined, moving under HELP.