### PR TITLE
Use full date for releases on stats page

### DIFF
--- a/js/stats.js
+++ b/js/stats.js
@@ -1163,7 +1163,6 @@ var statsObj = undefined;
 var currentRelease = undefined;
 var lastRelease = undefined;
 var dynamicTaxonMap = { };
-var dynamicReleaseDate = { };
 
 
 function setDynamicVariables() {
@@ -1189,9 +1188,7 @@ function initUI(statsObj) {
     var selRelease = document.getElementById("selected-release");
     if(selRelease) {
         for(var release of statsObj.stats) {
-            var sdate = simpleDate(release.release_date);
-            dynamicReleaseDate[sdate] = release.release_date;
-            selRelease.options[selRelease.options.length] = new Option(sdate);
+            selRelease.options[selRelease.options.length] = new Option(release.release_date);
         }
         selRelease.selectedIndex = selRelease.options.length - 1;
     }
@@ -1243,7 +1240,6 @@ function changeAnnotationAspect() {
 function changeRelease() {
     var selRelease = document.getElementById("selected-release");
     var newRelease = selRelease.options[selRelease.selectedIndex].value;
-    newRelease = dynamicReleaseDate[newRelease];
     // console.log("loading data for new release: ", newRelease);
     currentRelease = newRelease;
     var release = getRelease(statsObj, newRelease);


### PR DESCRIPTION
Fixes #407 

### Summary

This is a pretty simple change. The JavaScript used by the `stats.html` page was going out of its way to convert `release_date` values (in YYYY-MM-DD format) into a "simple dates" (YYYY-MM format) and maintain a mapping between the two. This change simply removes that code so that the full date shows up in the release picker.

### Demo

https://github.com/user-attachments/assets/be160c46-19ee-4491-ae93-d407d8ac0fb8

