### PR TITLE
Use new `@geneontology/web-components` package on ribbon sandbox and COVID-19 pages

### DIFF
--- a/_docs/ribbon.md
+++ b/_docs/ribbon.md
@@ -119,14 +119,4 @@ The data provided to the ribbon has to follow a certain JSON schema and a basic 
 
 ## Under the hood
 
-The full GO Ribbon web component is available on [ [GitHub](https://github.com/geneontology/wc-ribbon/tree/master/wc-go-ribbon){:target="blank"} ] and [ [NPM](https://www.npmjs.com/package/@geneontology/wc-go-ribbon){:target="blank"} ]. It includes all the components needed to display and interact the ribbon strips and table and is pre-configured to fetch data from the GO API. This version can easily be integrated in any website or framework and additional information are available on GitHub.
-
-Subparts of the ribbon can also be integrated independently:
-* Ribbon strips: [ [GitHub](https://github.com/geneontology/wc-ribbon/tree/master/wc-ribbon-strips){:target="blank"} ] [ [NPM](https://www.npmjs.com/package/wc-ribbon-strips){:target="blank"} ]: the top part containing the high level term labels as well as the colored cells representing the annotation volume of the genes of interest
-* Ribbon table: [ [GitHub](https://github.com/geneontology/wc-ribbon/tree/master/wc-ribbon-table){:target="blank"} ] [ [NPM](https://www.npmjs.com/package/wc-ribbon-table){:target="blank"} ] : the annotation table, which opens upon clicking one of the colored cell
-* Ribbon spinner: [ [GitHub](https://github.com/geneontology/wc-ribbon/tree/master/wc-spinner){:target="blank"} ]: generic spinner to notify of loading / blocking process
-
-Code available on [GitHub](https://github.com/geneontology/wc-ribbon)
-
-Powered by the GO API [http://api.geneontology.org/](http://api.geneontology.org/)
-
+The GO Ribbon is available as part of the GO Web Components package on [ [GitHub](https://github.com/geneontology/web-components){:target="blank"} ] and [ [NPM](https://www.npmjs.com/package/@geneontology/web-components){:target="blank"} ]. It includes all the components needed to display and interact the ribbon strips and table and is pre-configured to fetch data from the [GO API](https://api.geneontology.org/){:target="blank"}. This version can easily be integrated in any website or framework. Additional information is available in the [documentation](https://geneontology.github.io/web-components/){:target="blank"}.

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -20,4 +20,6 @@
 
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
     <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" />
+
+    <script type="module" src="https://unpkg.com/@geneontology/web-components@0.2.0"></script>
 </head>

--- a/_sass/custom/_typography.scss
+++ b/_sass/custom/_typography.scss
@@ -109,6 +109,10 @@ a:not(.btn):not(.yasr_btn):not(.list-group-item):not(.dropdown-menu__item__link)
     padding: 1rem 2rem;
 }
 
+.btn-no-radius {
+    border-radius: 0 !important;
+}
+
 .tt-input {
     border-radius: 25px;
 }

--- a/covid-19.html
+++ b/covid-19.html
@@ -4,54 +4,18 @@ permalink: /covid-19.html
 ---
 
 <style>
-    .banner {
-        background-color: red;
-        color: white;
-        border-radius: 5px;
-        padding: 10px;
-        text-align: center;
-        margin: 20px 0px;
-    }
-
-    .banner__warning {
-        display: inline-block;
-        text-align: left;
-        width: 15%;
-    }
-
-    .banner__disclaimer {
-        display: inline-block;
-        text-align: start;
-        width: 80%;
-    }
-
-    .ribbon__category--cell, .ribbon__subject--cell, .ribbon__subject--cell--no-annotation, .ribbon__subject__label--link, tr, th, td {
-        /* font-size: 14px !important; */
-        line-height: 1.0 !important;
-    }
-
-    .ribbon__subject--cell {
-        box-shadow: 0 1px 1px rgba(0,0,0,.26);
-    }
-
-    .ribbon__category--cell:hover {
-        font-weight: 800 !important;
-    }
-
-    .wc-ribbon-cell, wc-ribbon-subject, wc-ribbon-strips {
-        line-height: 1.0 !important;
-    }
-
     li {
         margin-left: 30px;
+    }
+
+    go-annotation-ribbon-strips {
+        --group-height: 14em;
+        font-size: 80%;
     }
 </style>
 
 
 <script src="js/covid.js"></script>
-<script type="module" src="https://unpkg.com/@geneontology/wc-ribbon-strips/dist/wc-ribbon-strips/wc-ribbon-strips.esm.js"></script>
-<script nomodule="" src="https://unpkg.com/@geneontology/wc-ribbon-strips/dist/wc-ribbon-strips/wc-ribbon-strips.js"></script>
-
 
 <div class="container" style="width:95%">
     <div class="row" style="margin:0rem 2rem">
@@ -77,7 +41,13 @@ permalink: /covid-19.html
         <h2 id="hp-sars-cov-2-ce">Human proteins used by SARS-CoV-2 to enter human cells</h2>
         The virus has been shown to require two human proteins (<a href="https://amigo.geneontology.org/amigo/gene_product/UniProtKB:Q9BYF1" target="_blank">ACE2</a>, <a href="https://amigo.geneontology.org/amigo/gene_product/UniProtKB:O15393" target="_blank">TMPRSS2</a>) for cell entry<sup><a href="#references">1,2</a></sup>.
         These are the same proteins used by <a href="https://www.ncbi.nlm.nih.gov/pubmed/21068237" target="blank">SARS-CoV<sup>4</sup></a>, the cause of the 2002-2004 SARS epidemic.
-        <div id="ribbon-covid-cell-entry" style="padding-top: 55px; padding-bottom: 30px; overflow-x: auto; width: 1400px;"></div>
+        <div id="ribbon-covid-cell-entry" style="padding-top: 55px; padding-bottom: 30px; overflow-x: auto; width: 1400px;">
+            <go-annotation-ribbon-strips
+                id="ribbon-cell-entry"
+                show-all-annotations-group="false"
+                subjects="UniProtKB:Q9BYF1,UniProtKB:O15393"
+            ></go-annotation-ribbon-strips>
+        </div>
 
         <table style="width:100%">
             <tr>
@@ -104,7 +74,12 @@ permalink: /covid-19.html
 
         <br><br>
         <b>SARS-CoV-2 gene</b>: <select id="selected-covid-gene" onchange="changeCOVID()"></select>
-        <div id="ribbon-covid-gene" style="padding-top: 55px; padding-bottom: 30px; overflow-x: auto; width: 1400px;"></div>
+        <div id="ribbon-covid-gene" style="padding-top: 55px; padding-bottom: 30px; overflow-x: auto; width: 1400px;">
+            <go-annotation-ribbon-strips
+                id="ribbon-covid"
+                show-all-annotations-group="false"
+            ></go-annotation-ribbon-strips>
+        </div>
 
 
         <table style="width:100%"><tr>

--- a/js/covid.js
+++ b/js/covid.js
@@ -10760,7 +10760,6 @@ function initUI(covid_data) {
     initEnrichment();
     ribbonCOVID(covid_genes[0]);
     updateEnrich(covid_genes[0]);
-    ribbonCellEntry();
 }
 
 function initEnrichment() {
@@ -10786,84 +10785,20 @@ function initEnrichment() {
 }
 
 function ribbonCOVID(covid_gene) {
-    let baseAPIURL = "http://api.geneontology.org/api/ontology/ribbon/";
     let data = covid_data[covid_gene];
-    let subjects = data.map(elt => { return elt.amigoid }).join("&subject=");
-    let query = baseAPIURL + '?subset=goslim_agr&subject=' + subjects;
-    // console.log('API query is ' + query);
-
-    var parent = document.getElementById("ribbon-covid-gene");
-    parent.innerHTML = 'Loading GO Ribbon...';
-
-    fetch(query)
-    .then(response => {
-        response.json().then(data => {
-            // console.log(data);
-            var element = document.createElement("wc-ribbon-strips");
-            element.setAttribute("id", "wc-ribbon-covid");
-            element.setAttribute("fire-event-on-empty-cells", false)
-            element.setAttribute("add-cell-all", false);
-            element.setAttribute("selection-mode", 0);
-            element.setAttribute("subject-position", 1);
-            element.setAttribute("data", JSON.stringify(data));
-
-            parent.innerHTML = '';
-            parent.appendChild(element);
-
-            // add a listener whenever a cell is clicked
-            document.addEventListener('cellClick', function hideMenu(e, v) {
-                console.log('Cell Clicked', e.detail);
-                window.open('http://amigo.geneontology.org/amigo/gene_product/' + e.detail.subjects[0].id + '?fq=regulates_closure:\"' + e.detail.group.id + '\"')
-            });
-
-            // add a listener whenever a group is clicked
-            document.addEventListener('groupClick', function hideMenu(e, v) {
-                console.log('Group Clicked', e.detail);
-                window.open('http://amigo.geneontology.org/amigo/term/' + e.detail.group.id, '_blank');
-            });
-
-        })
-    })
+    const ribbon = document.getElementById("ribbon-covid");
+    ribbon.subjects = data.map(elt => elt.amigoid).join(",");
 }
 
+// add a listener whenever a cell is clicked
+document.addEventListener('cellClick', function hideMenu(e, v) {
+    console.log('Cell Clicked', e.detail);
+    window.open('http://amigo.geneontology.org/amigo/gene_product/' + e.detail.subjects[0].id + '?fq=regulates_closure:\"' + e.detail.group.id + '\"')
+});
 
-function ribbonCellEntry() {
-    let baseAPIURL = "http://api.geneontology.org/api/ontology/ribbon/";
-    let subjects = ["UniProtKB:Q9BYF1", "UniProtKB:O15393"].join("&subject=");
-    let query = baseAPIURL + '?subset=goslim_agr&subject=' + subjects;
-    // console.log("entry: ", query);
-
-    var parent = document.getElementById("ribbon-covid-cell-entry");
-    parent.innerHTML = 'Loading GO Ribbon...';
-
-    fetch(query)
-    .then(response => {
-        response.json().then(data => {
-            var element = document.createElement("wc-ribbon-strips");
-            element.setAttribute("id", "wc-ribbon-cell-entry");
-            element.setAttribute("fire-event-on-empty-cells", false)
-            element.setAttribute("add-cell-all", false);
-            element.setAttribute("selection-mode", 0);
-            element.setAttribute("subject-position", 1);
-            element.setAttribute("data", JSON.stringify(data));
-
-            parent.innerHTML = '';
-            parent.appendChild(element);
-
-            // // add a listener whenever a cell is clicked
-            // document.addEventListener('cellClick', function hideMenu(e, v) {
-            //     console.log('Cell Clicked' , e.detail);
-            // });
-
-            // // add a listener whenever a group is clicked
-            // document.addEventListener('groupClick', function hideMenu(e, v) {
-            //     console.log('Group Clicked' , e.detail);
-            //     window.open('http://amigo.geneontology.org/amigo/term/' + e.detail.group.id, '_blank');
-            // });
-
-        })
-    })
-}
-
-
+// add a listener whenever a group is clicked
+document.addEventListener('groupClick', function hideMenu(e, v) {
+    console.log('Group Clicked', e.detail);
+    window.open('http://amigo.geneontology.org/amigo/term/' + e.detail.group.id, '_blank');
+});
 

--- a/js/ribbon.js
+++ b/js/ribbon.js
@@ -60,4 +60,9 @@ function view() {
     var ids = input_enrichment.value.split("\n");
     var ribbon = document.getElementById("ribbon");
     ribbon.subjects = ids.join(",");
-}    
+}
+
+function clearRibbon() {
+    var ribbon = document.getElementById("ribbon");
+    ribbon.subjects = "";
+}

--- a/ribbon.html
+++ b/ribbon.html
@@ -3,155 +3,111 @@ layout: default
 permalink: /ribbon.html
 ---
 
-
 <style>
-    .banner {
-        background-color: red;
-        color: white;
-        border-radius: 5px;
-        padding: 10px;
-        text-align: center;
-        margin: 20px 0px;
-    }
+  go-annotation-ribbon {
+    --group-height: 15em;
 
-    .banner__warning {
-        display: inline-block;
-        text-align: left;
-        width: 15%;
-    }
+    font-size: 80%;
+    margin-bottom: 8rem;
+  }
 
-    .banner__disclaimer {
-        display: inline-block;
-        text-align: start;
-        width: 80%;
-    }
+  .btn, .btn:hover, .btn:focus, .btn:active {
+    background-color: #3F51B5;
+    border: 1px solid black !important;
+  }
 
-    .ribbon__category--cell, .ribbon__subject--cell, .ribbon__subject--cell--no-annotation, .ribbon__subject__label--link, tr, th, td {
-        /* font-size: 14px !important; */
-        line-height: 1.0 !important;
-    }
+  #ribbon-sandbox-input {
+    width: 320px;
+    resize: none;
+    font-size: 14px;
+  }
 
-    .ribbon__subject--cell {
-        box-shadow: 0 1px 1px rgba(0,0,0,.26);
-    }
-
-    .ribbon__category--cell:hover {
-        font-weight: 800 !important;
-    }
-
-    .wc-ribbon-cell, wc-ribbon-subject, wc-ribbon-strips, wc-ribbon-table {
-        line-height: 1.0 !important;
-        font-size: 14px !important;
-    }
-
-    li {
-        margin-left: 0px;
-    }
-
-    h3 {
-        font-size: 16px;
-    }
-
-    .cell {
-        border: 1px solid black; background-color: white; height: 15px; width: 15px; display: inline-block; vertical-align: sub;
-    }
-
-    .table__row__supercell__cell__link {
-        color: rgb(73, 101, 194);
-        text-decoration: none;
-    }
-
-    .table__header__cell {
-        padding: 2px;
-        font-weight: 800 !important;
-    }
-
-    .clicked {
-        border: 2px solid red;
-        box-shadow: 0px 0px 8px red !important;
-    }
-
-    .table__row__supercell {
-        vertical-align: top !important;
-        border-bottom: 1px solid #ddd;
-    }
-
+  .container-fluid {
+    width: 90%;
+  }
 </style>
 
 <script src="js/ribbon.js"></script>
 
-<script type="module" src="https://unpkg.com/@geneontology/wc-go-ribbon/dist/wc-go-ribbon/wc-go-ribbon.esm.js"></script>
-<script nomodule="" src="https://unpkg.com/@geneontology/wc-go-ribbon/dist/wc-go-ribbon/wc-go-ribbon.js"></script>
+<div class="container-fluid u-padding-bottom-xlarge">
 
-<script type="module" src="https://unpkg.com/@geneontology/wc-go-autocomplete/dist/wc-go-autocomplete/wc-go-autocomplete.esm.js"></script>
-<script nomodule="" src="https://unpkg.com/@geneontology/wc-go-autocomplete/dist/wc-go-autocomplete/wc-go-autocomplete.js"></script>
+  <h1>Gene Ontology Ribbon Sandbox</h1>
 
+  <p>
+    The GO Ribbon provides a visual summary of gene functions and a quick way to browse the GO
+    annotations for a gene or gene set.
+  </p>
 
+  <p>
+    To further investigate the GO annotations grouped under a high level term, click on the colored
+    cells for your gene of interest.
+  </p>
 
-<div class="container" style="width:95%">
-    <div class="row" style="margin:0rem 2rem">
+  <p>
+    Questions about the Ribbon ? [<a href="/docs/ribbon.html">GO Ribbon documentation</a>] [<a
+      href="https://help.geneontology.org/">Helpdesk</a>].
+  </p>
 
-        <h1>Gene Ontology Ribbon Sandbox</h1>
+  <hr>
 
-        <p>
-        The GO Ribbon provides a visual summary of gene functions and a quick way to browse the GO annotations for a gene or gene set.
-        </p>
+  <div class="row">
 
-        <p>
-        To further investigate the GO annotations grouped under a high level term, click on the colored cells for your gene of interest.
-        </p>
-
-        <p>
-        Questions about the Ribbon ? [<a href="/docs/ribbon.html">GO Ribbon documentation</a>] [<a href="https://help.geneontology.org/">Helpdesk</a>].
-        </p>
-
-        <hr>
-
-        <div style="margin-bottom: 10rem; border: 1px solid black; border-radius: 25px;">
-
-            <div style="margin-left: 2rem; display: inline-block; vertical-align: top">
-                <strong>Search and add gene to the GO ribbon:</strong><br><small>(can use gene symbol or model organism ID such as RGD:3889)</small><br>
-                <wc-go-autocomplete id="ac"></wc-go-autocomplete>
-            </div>
-
-            <div style="margin: 6rem 3rem; display: inline-block; vertical-align: top;"><strong> OR </strong></div>
-
-            <div style="display: inline-block">
-                <strong>Load GO ribbon with multiple genes:</strong><br><small>(requires model organism IDs such as RGD:3889, MGI:1099800, HGNC:11998)</small><br>
-                <textarea id="ribbon-sandbox-input" rows="4" name="input" placeholder="Enter gene IDs (eg HGNC:11998, MGI:1099800...)" style="width:320px; resize: none; margin-bottom: 5px; font-size: 14px; display: inline-block"></textarea>
-                <div class="input-group-btn" style="display: inline-block; position: absolute; padding-left: 1rem;">
-                    <button type="button" class="btn btn-primary u-no-transform u-anim-zoom-in" style="background-color: #3F51B5; border-color: black; margin-bottom: 1rem; display: block" onclick="getExample()" title="Cycle through different Gene Set examples">
-                        Examples
-                    </button>
-                    <button type="button" class="btn btn-primary u-no-transform u-anim-move-right" style="background-color: #3F51B5; border-color: black; display: block" onclick="view()" title="View GO Ribbon for above gene set">
-                        View <i class="fa-solid fa-chevron-right u-line-height-single"></i>
-                    </button>
-                </div>
-            </div>
-
-            <div style="margin: 6rem 3rem; display: inline-block; vertical-align: top;">  </div>
-
-            <div style="display: inline-block; vertical-align: top;">
-                    <strong>Remove all genes from GO ribbon:</strong><br>
-                <button onclick="document.getElementById('ribbon').subjects=''" style="background-color: #3F51B5; border-color: black; padding: 10px; border-radius: 0px 0px calc(8px + 1.5vw) 0px;" class="btn btn-primary u-no-transform u-anim-move-right">Clear GO ribbon</button>
-            </div>
-
-        </div>
-
-
-
-        <!-- Ribbon itself -->
-        <wc-go-ribbon id="ribbon" subjects="RGD:620474,RGD:3889"></wc-go-ribbon>
-
-
-        <h2 style="margin-top:50px">Additional Notes</h2>
-        <ul>
-            <li>The Ribbon provides a summary of the annotations associated to your genes, but it does not inform on which are the most relevant functions in a gene set. To find out the statistically relevant functions of a gene set, please use the <a href="/docs/go-enrichment-analysis/">Enrichment Analysis</a> approach</li>
-            <li>The <a href="/covid-19.html">GO COVID-19 page</a> is an illustration of how the GO Ribbon and Enrichment Analysis can be used together to both show the existing functions of a gene set and highlight the functions that are over or under represented (over representation test)</li>
-            <li>The Ribbon is a generic web component that can easily be integrated in other websites, independenly of the framework used. It is freely available on <a href="https://github.com/geneontology/wc-ribbon" target="blank">GitHub</a>. As an example, the Ribbon is used to represent both GO, Disease and Expression data on the <a href="https://www.alliancegenome.org/" target="blank">Alliance website</a></li>
-        </ul>
-
+    <div class="col-xs-12 col-sm-6 col-md-4">
+      <strong>Search and add gene to the GO ribbon:</strong>
+      <br>
+      <small>(can use gene symbol or model organism ID such as RGD:3889)</small>
+      <br>
+      <go-entity-autocomplete id="ac"></go-entity-autocomplete>
     </div>
 
-    <br><br><br>
+    <div class="col-xs-12 col-sm-1 col-md-1">&mdash; OR &mdash;</div>
+
+    <div class="col-xs-12 col-sm-5 col-md-5">
+      <strong>Load GO ribbon with multiple genes:</strong>
+      <br>
+      <small>(requires model organism IDs such as RGD:3889, MGI:1099800, HGNC:11998)</small>
+      <br>
+      <textarea id="ribbon-sandbox-input" rows="4" name="input"
+                placeholder="Enter gene IDs (eg HGNC:11998, MGI:1099800...)"></textarea>
+      <div>
+        <button type="button" class="btn btn-primary btn-no-radius u-no-transform"
+                onclick="getExample()" title="Cycle through different Gene Set examples">
+          Load Example
+        </button>
+        <button type="button" class="btn btn-primary btn-no-radius u-no-transform" onclick="view()"
+                title="View GO Ribbon for above gene set">
+          View <i class="fa-solid fa-chevron-right u-line-height-single"></i>
+        </button>
+      </div>
+    </div>
+
+    <div class="col-xs-12 col-sm-12 col-md-2">
+      <button type="button" onclick="clearRibbon()"
+              class="btn btn-primary btn-no-radius u-no-transform">
+        Clear Ribbon
+      </button>
+    </div>
+
+  </div>
+
+  <go-annotation-ribbon id="ribbon" subjects="RGD:620474,RGD:3889"></go-annotation-ribbon>
+
+  <h2>Additional Notes</h2>
+  <ul>
+    <li>The Ribbon provides a summary of the annotations associated to your genes, but it does not
+      inform on which are the most relevant functions in a gene set. To find out the statistically
+      relevant functions of a gene set, please use the <a href="/docs/go-enrichment-analysis/">Enrichment
+        Analysis</a> approach
+    </li>
+    <li>The <a href="/covid-19.html">GO COVID-19 page</a> is an illustration of how the GO Ribbon
+      and Enrichment Analysis can be used together to both show the existing functions of a gene set
+      and highlight the functions that are over or under represented (over representation test)
+    </li>
+    <li>The Ribbon is a generic web component that can easily be integrated in other websites,
+      independenly of the framework used. See the
+      <a href="https://geneontology.github.io/web-components">documentation</a> for more information
+      on how to use it or to see <a href="https://geneontology.github.io/web-components/showcase">sites
+        that already use it</a>.
+    </li>
+  </ul>
 </div>


### PR DESCRIPTION
Fixes #771 

These changes replace the old `@geneontology/wc-ribbon` package with the new `@geneontology/web-components` package. The changes affect three pages:

**Ribbon Sandbox** (https://geneontology.org/ribbon)

* Replaced the old `<wc-go-ribbon>` element with new `<go-annotation-ribbon>` element.
* Updated content of the "Additional Notes" section to point to new component documentation site.
* General cleanup of layout and HTML.
* Screenshot of updated page:
<img width="1712" height="1406" alt="image" src="https://github.com/user-attachments/assets/11923913-2a55-4c79-b99f-c8b7c9e85a4b" />

**Ribbon docs page** (https://geneontology.org/docs/ribbon.html)

* Updated content of the "Under the hood" section to point to new docs site, GitHub repo, and NPM page.
* Removed overly technical information that is covered by new docs site.

**COVID-19 page** (https://geneontology.org/covid-19.html)

* Replaced the old `<wc-ribbon-strips>` element with new `<go-annotation-ribbon-strips>` element.
* Remove unnecessary manual data fetching, which is the cause of the ribbons not loading correctly on the current page.
* Screenshot of updated page:
<img width="1712" height="1406" alt="image" src="https://github.com/user-attachments/assets/1b4660f4-88d0-418f-83ef-844555511451" />

