### PR TITLE
Upgrade to v1 of `@geneontology/web-components` package

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -21,5 +21,5 @@
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
     <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" />
 
-    <script type="module" src="https://unpkg.com/@geneontology/web-components@0.2.0"></script>
+    <script type="module" src="https://unpkg.com/@geneontology/web-components@1"></script>
 </head>


### PR DESCRIPTION
These changes bring in the latest `1.0.0` version of the `@geneontology/web-components` package. Because of the `@1` version specifier this will float with the latest version in the 1.x.x series. That is, when we release version `1.1.0` of `@geneontology/web-components` we won't need to make any change here to pick up that version. If that's _not_ desirable please let me know and we can go back to specifying an exact version here.