### PR TITLE
Clarify GPAD 2.0 file header requirements

### DIFF
--- a/_docs/gene-product-association-data-gpad-format.md
+++ b/_docs/gene-product-association-data-gpad-format.md
@@ -21,24 +21,20 @@ For general information on GO annotations, please see the [introduction to GO an
 
 **Mandatory elements of the GPAD 2.0 file header**  
 
-Three lines are required in the GPAD 2. header as shown below.
-
 !`gpad-version:` 2.0  <br>
-!`generated-by:` database must be listed in [dbxrefs.yaml](https://github.com/geneontology/go-site/blob/master/metadata/db-xrefs.yaml)  <br>
+!`generated-by:` database (must be listed in [dbxrefs.yaml](https://github.com/geneontology/go-site/blob/master/metadata/db-xrefs.yaml))  <br>
 !`date-generated:` YYYY-MM-DD or YYYY-MM-DDTHH:MM <br>
 
-**Other header elements**
+**Other header elements may be included such as links to the submitters project page, funding sources, ontology versions, etc.**
 
-Other information, such as links to the submitters project page, funding sources, ontology versions, etc., may be included in an association file as shown below.
-
-!URL: e.g. http://www.yeastgenome.org/ <br>
-!Project-release: e.g. WS275 <br>
-!Funding: e.g. NHGRI <br>
-!Columns: file format written out <br>
-!go-version: PURL <br>
-!ro-version: PURL <br>
-!gorel-version: PURL <br>
-!eco-version: PURL <br>
+! URL: e.g. http://www.yeastgenome.org/ <br>
+! Project-release: e.g. WS275 <br>
+! Funding: e.g. NHGRI <br>
+! Columns: file format written out <br>
+! go-version: PURL <br>
+! ro-version: PURL <br>
+! gorel-version: PURL <br>
+! eco-version: PURL <br>
     
 ### GPAD file fields
 The GPAD format comprises 12 tab-delimited fields.  Some fields are optional, some fields are mandatory and cardinality varies by field and other conditions.  For fields that permit multiple values, values should be separated by pipes (\|) for `OR` statements and commas (,) for `AND` statements.


### PR DESCRIPTION
Updated the GPAD 2.0 file header section to clarify the mandatory elements and their formatting. Improved the wording for optional header elements.