### PR TITLE
Update collaborations section in documentation

### DIFF
--- a/_docs/collaborations.md
+++ b/_docs/collaborations.md
@@ -7,18 +7,15 @@ redirect_from: /page/syngo-synapse-biology
 # Collaborations
 The GO Consortium collaborates with many other groups on a wide variety of topics, particularly with groups whose expertise in specific areas of biology, or a complementary ontology project, would help to improve the usefulness of the GO knowledgebase. We welcome your feedback and contributions. Please [let us know](https://help.geneontology.org/){:target="blank"} if you are interested in a possible collaboration.
 
-## Annotation/Ontology development projects
-
-
 <!-- 
 | Project | Description |
 |---------|-------------|
 | [SynGO](https://www.syngoportal.org/){:target="blank"} | Capturing synaptic processes and cellular components<br>[Stanley Center for Psychiatric Research at the Broad Institute](https://www.broadinstitute.org/stanley){:target="blank"} |
 | [Critical Assessment of Functional Annotation](https://biofunctionprediction.org/cafa/){:target="blank"} | An ongoing, global, community-driven effort to evaluate and improve the computational annotation of protein function |
 | [Gene Regulation Consortium (GRECO)](http://thegreco.org/){:target="blank"} | GRECO aspires to build a 'knowledge commons' for gene regulation research, coordinating groups who generate and collate knowledge on gene transcription regulation and building a common knowledge management framework |
--->>
+-->
 
-## Domain-specific expertise
+## Domain-specific experts
 
 - __Extracellular Matrix__: Alexandra Naba, Daiqing Chen, Matrisome
 - __Pathogens__: Gene Godbold, Signature Science
@@ -26,7 +23,6 @@ The GO Consortium collaborates with many other groups on a wide variety of topic
 - *__S. pombe__* __annotations__: Jacqueline	Hayles
 
 
-- 
 ## Ontologies imported by the GO Consortium
 
 The following ontologies are imported into GO:


### PR DESCRIPTION
Removed the annotation/ontology development projects section and updated the domain-specific expertise heading.