### PR TITLE
Update downloads page links for the new EBI GOEx annotation layout

### DIFF
--- a/scripts/update_downloads.py
+++ b/scripts/update_downloads.py
@@ -87,13 +87,30 @@ def generate_table_row(org, code):
     taxonomic_group_id = org.get('taxonomic_group', '')
     taxonomic_group = get_taxonomic_group_name(taxonomic_group_id)
 
+    # As of the EBI GOEx filename simplification (go-site#2681) the
+    # pipeline publishes SPECIES-{uniprot,mod}.<ext>.gz under
+    # annotations/{gaf,gpad,gpi}/. Every species has a -uniprot variant;
+    # only MOD-managed species (goex.yaml group != UniProt) also get -mod.
+    base = 'https://skyhook.geneontology.io/pipeline-from-goa/main/annotations'
+    is_mod = bool(org.get('group')) and org.get('group') != 'UniProt'
+
+    if is_mod:
+        mod_cell = (f'<a href="{base}/gaf/{code}-mod.gaf.gz">'
+                    f'{code}-mod.gaf.gz</a>')
+    else:
+        mod_cell = '&mdash;'
+    uniprot_cell = (f'<a href="{base}/gaf/{code}-uniprot.gaf.gz">'
+                    f'{code}-uniprot.gaf.gz</a>')
+    gpi_cell = (f'<a href="{base}/gpi/{code}-uniprot.gpi.gz">'
+                f'{code}-uniprot.gpi.gz</a>')
+
     return f'''        <tr>
           <td>{full_name}</td>
           <td>{common_name}</td>
           <td>{taxonomic_group}</td>
-          <td><a href="https://skyhook.geneontology.io/pipeline-from-goa/main/annotations/{code}.gaf.gz">{code}.gaf.gz</a></td>
-          <td><a href="https://skyhook.geneontology.io/pipeline-from-goa/main/annotations/{code}-uniprot.gaf.gz">{code}-uniprot.gaf.gz</a></td>
-          <td><a href="https://ftp.ebi.ac.uk/pub/contrib/goa/goex/current/gpi/{code}.gpi.gz">{code}.gpi.gz</a></td>
+          <td>{mod_cell}</td>
+          <td>{uniprot_cell}</td>
+          <td>{gpi_cell}</td>
         </tr>'''
 
 


### PR DESCRIPTION
Updates `scripts/update_downloads.py` to point at the new annotation layout.

**Background:** EBI GOEx simplified its per-species filenames to
`SPECIES-{uniprot,mod}` (geneontology/go-site#2681), and the `pipeline-from-goa`
pipeline publishes them at
`https://skyhook.geneontology.io/pipeline-from-goa/main/annotations/{gaf,gpad,gpi}/SPECIES-{uniprot,mod}.<ext>.gz`.
The current `generate_table_row` linked the old flat paths
(`annotations/{code}.gaf.gz`, `annotations/{code}-uniprot.gaf.gz`) and GPI from
EBI, all of which are now wrong.

**Changes (only `generate_table_row`):**
- UniProt GAF column → `annotations/gaf/{code}-uniprot.gaf.gz` (every species).
- MOD GAF column → `annotations/gaf/{code}-mod.gaf.gz`, emitted only for
  MOD-managed species (`group != UniProt`); an em-dash otherwise (previously a
  `{code}.gaf.gz` link was emitted for *every* species, 404ing for the ~150
  UniProt-only ones).
- GPI column → skyhook `annotations/gpi/{code}-uniprot.gpi.gz` (was EBI).

Validated by running the script against live `goex.yaml`: 171 UniProt GAF links,
MOD links only for `group != UniProt`, GPI on skyhook, zero old-flat/EBI links.

**Known issue (tracked, not blocking):** 5 CGD species — CANTI, CLALU, DEBHA,
LODEL, PICGU — are `group: CGD` in goex.yaml but EBI ships them UniProt-only, so
their `-mod` links 404 until goex.yaml/EBI is reconciled. Filed as
geneontology/go-site#2683. The `group != UniProt` signal is correct; these 5
fall out automatically once that bug is fixed.

Tracking: geneontology/pipeline#396.

_— Posted by Claude Code agent on behalf of @kltm._
