### PR TITLE
Downloads page: serve by-organism annotations in-site, link to current

### DIFF
--- a/_docs/download-go-annotations-downloads.html
+++ b/_docs/download-go-annotations-downloads.html
@@ -1,0 +1,1662 @@
+---
+title: Download annotations by organism
+permalink: /docs/download-go-annotations/downloads/
+---
+
+<div class="container">
+  <h1>GO Annotation Downloads</h1>
+
+  <h2>Overview</h2>
+  <p>Gene association files ingested from GO Consortium members are shown in the table below. These files follow the GO annotation format and are compressed using gzip. Please consult the upstream resource information for additional context. If you find any annotation errors, please report them through the <a href="http://help.geneontology.org/">GO Helpdesk</a>.</p>
+
+  <h2>Filtered Files</h2>
+  <p>The files shown below are taxon-specific files created through collaborative efforts, particularly from model organism database groups. All the files in this table have been filtered using the annotation file QC pipeline. A critical filtering requirement restricts particular organism IDs to specific authorized projects. The current list of authoritative groups and major model organisms can be found in the tables below.</p>
+
+  <h2>Common Model Organisms</h2>
+  <div class="table-responsive">
+    <table class="table table-striped table-hover">
+      <thead>
+        <tr>
+          <th>Organism</th>
+          <th>Common Name</th>
+          <th>Taxonomic Group</th>
+          <th>MOD ID-centric File</th>
+          <th>UniProt ID-centric File</th>
+          <th>GPI File</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Homo sapiens</td>
+          <td>Human</td>
+          <td>Vertebrates</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/HUMAN-uniprot.gaf.gz">HUMAN-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/HUMAN-uniprot.gpi.gz">HUMAN-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Arabidopsis thaliana</td>
+          <td>Mouse-ear cress</td>
+          <td>Plants</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/ARATH-mod.gaf.gz">ARATH-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/ARATH-uniprot.gaf.gz">ARATH-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/ARATH-uniprot.gpi.gz">ARATH-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Candida albicans</td>
+          <td>Candida</td>
+          <td>Fungi</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CANAL-mod.gaf.gz">CANAL-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CANAL-uniprot.gaf.gz">CANAL-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/CANAL-uniprot.gpi.gz">CANAL-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Candida dubliniensis</td>
+          <td>C. dubliniensis</td>
+          <td>Fungi</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CANDC-mod.gaf.gz">CANDC-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CANDC-uniprot.gaf.gz">CANDC-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/CANDC-uniprot.gpi.gz">CANDC-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Candida glabrata (strain ATCC 2001 / BCRC 20586 / JCM 3761 / NBRC 0622 / NRRL Y-65 / CBS 138) (Nakaseomyces glabratus)</td>
+          <td></td>
+          <td>Fungi</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CANGA-mod.gaf.gz">CANGA-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CANGA-uniprot.gaf.gz">CANGA-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/CANGA-uniprot.gpi.gz">CANGA-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Candida orthopsilosis (strain 90-125) (Co 90-125)</td>
+          <td></td>
+          <td>Fungi</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CANO9-mod.gaf.gz">CANO9-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CANO9-uniprot.gaf.gz">CANO9-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/CANO9-uniprot.gpi.gz">CANO9-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Candida parapsilosis (strain CDC 317 / ATCC MYA-4646)</td>
+          <td></td>
+          <td>Fungi</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CANPC-mod.gaf.gz">CANPC-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CANPC-uniprot.gaf.gz">CANPC-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/CANPC-uniprot.gpi.gz">CANPC-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Candida tropicalis (strain ATCC MYA-3404 / T1)</td>
+          <td></td>
+          <td>Fungi</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CANTT-mod.gaf.gz">CANTT-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CANTT-uniprot.gaf.gz">CANTT-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/CANTT-uniprot.gpi.gz">CANTT-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Clavispora lusitaniae (strain ATCC 42720)</td>
+          <td></td>
+          <td>Fungi</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CLAL4-mod.gaf.gz">CLAL4-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CLAL4-uniprot.gaf.gz">CLAL4-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/CLAL4-uniprot.gpi.gz">CLAL4-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Danio rerio</td>
+          <td>Zebrafish</td>
+          <td>Vertebrates</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/DANRE-mod.gaf.gz">DANRE-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/DANRE-uniprot.gaf.gz">DANRE-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/DANRE-uniprot.gpi.gz">DANRE-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Dictyostelium discoideum</td>
+          <td>Social amoeba</td>
+          <td>Amoebozoa</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/DICDI-mod.gaf.gz">DICDI-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/DICDI-uniprot.gaf.gz">DICDI-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/DICDI-uniprot.gpi.gz">DICDI-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Drosophila melanogaster</td>
+          <td>Fruit fly</td>
+          <td>Arthropods</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/DROME-mod.gaf.gz">DROME-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/DROME-uniprot.gaf.gz">DROME-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/DROME-uniprot.gpi.gz">DROME-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Escherichia coli K12</td>
+          <td>E. coli K12</td>
+          <td>Bacteria</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/ECOLI-mod.gaf.gz">ECOLI-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/ECOLI-uniprot.gaf.gz">ECOLI-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/ECOLI-uniprot.gpi.gz">ECOLI-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Mus musculus</td>
+          <td>Mouse</td>
+          <td>Vertebrates</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/MOUSE-mod.gaf.gz">MOUSE-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/MOUSE-uniprot.gaf.gz">MOUSE-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/MOUSE-uniprot.gpi.gz">MOUSE-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Nematode C. elegans</td>
+          <td>Nematode C. elegans</td>
+          <td>Nematodes</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CAEEL-mod.gaf.gz">CAEEL-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CAEEL-uniprot.gaf.gz">CAEEL-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/CAEEL-uniprot.gpi.gz">CAEEL-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Rattus norvegicus</td>
+          <td>Rat</td>
+          <td>Vertebrates</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/RAT-mod.gaf.gz">RAT-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/RAT-uniprot.gaf.gz">RAT-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/RAT-uniprot.gpi.gz">RAT-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Saccharomyces cerevisiae</td>
+          <td>"Baker's yeast"</td>
+          <td>Fungi</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/YEAST-mod.gaf.gz">YEAST-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/YEAST-uniprot.gaf.gz">YEAST-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/YEAST-uniprot.gpi.gz">YEAST-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Schizosaccharomyces japonicus</td>
+          <td>Fission yeast</td>
+          <td>Fungi</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/SCHJY-mod.gaf.gz">SCHJY-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/SCHJY-uniprot.gaf.gz">SCHJY-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/SCHJY-uniprot.gpi.gz">SCHJY-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Schizosaccharomyces pombe</td>
+          <td>Fission yeast</td>
+          <td>Fungi</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/SCHPO-mod.gaf.gz">SCHPO-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/SCHPO-uniprot.gaf.gz">SCHPO-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/SCHPO-uniprot.gpi.gz">SCHPO-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Xenopus laevis</td>
+          <td>African clawed frog</td>
+          <td>Vertebrates</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/XENLA-mod.gaf.gz">XENLA-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/XENLA-uniprot.gaf.gz">XENLA-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/XENLA-uniprot.gpi.gz">XENLA-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Xenopus tropicalis</td>
+          <td>Western clawed frog</td>
+          <td>Vertebrates</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/XENTR-mod.gaf.gz">XENTR-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/XENTR-uniprot.gaf.gz">XENTR-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/XENTR-uniprot.gpi.gz">XENTR-uniprot.gpi.gz</a></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h2>All Organisms</h2>
+  <p>
+    <input type="text" id="species-filter"
+           placeholder="Filter species by name, code, or group&hellip;"
+           onkeyup="filterSpecies()" aria-label="Filter species"
+           style="width: 100%; max-width: 420px; padding: 8px 10px; border: 1px solid #ccc; border-radius: 4px;">
+  </p>
+  <div class="table-responsive">
+    <table class="table table-striped table-hover" id="all-organisms-table">
+      <thead>
+        <tr>
+          <th>Organism</th>
+          <th>Common Name</th>
+          <th>Taxonomic Group</th>
+          <th>MOD ID-centric File</th>
+          <th>UniProt ID-centric File</th>
+          <th>GPI File</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Acinetobacter baumannii (strain ATCC 19606 / DSM 30007 / JCM 6841 / CCUG 19606 / CIP 70.34 / NBRC 109757 / NCIMB 12457 / NCTC 12156 / 81)</td>
+          <td>A. baumannii ATCC 19606</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/ACIB2-uniprot.gaf.gz">ACIB2-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/ACIB2-uniprot.gpi.gz">ACIB2-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Anolis carolinensis</td>
+          <td>Lizard</td>
+          <td>Vertebrates</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/ANOCA-uniprot.gaf.gz">ANOCA-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/ANOCA-uniprot.gpi.gz">ANOCA-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Anopheles gambiae</td>
+          <td>Mosquito</td>
+          <td>Arthropods</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/ANOGA-uniprot.gaf.gz">ANOGA-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/ANOGA-uniprot.gpi.gz">ANOGA-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Aquifex aeolicus</td>
+          <td>Aquaficae bacteria</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/AQUAE-uniprot.gaf.gz">AQUAE-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/AQUAE-uniprot.gpi.gz">AQUAE-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Arabidopsis thaliana</td>
+          <td>Mouse-ear cress</td>
+          <td>Plants</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/ARATH-mod.gaf.gz">ARATH-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/ARATH-uniprot.gaf.gz">ARATH-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/ARATH-uniprot.gpi.gz">ARATH-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Aspergillus fumigatus</td>
+          <td>A. fumigatus</td>
+          <td>Fungi</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/ASPFU-uniprot.gaf.gz">ASPFU-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/ASPFU-uniprot.gpi.gz">ASPFU-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Bacillus anthracis</td>
+          <td>Antrax</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/BACAN-uniprot.gaf.gz">BACAN-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/BACAN-uniprot.gpi.gz">BACAN-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Bacillus cereus</td>
+          <td>B. cereus</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/BACCR-uniprot.gaf.gz">BACCR-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/BACCR-uniprot.gpi.gz">BACCR-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Bacillus subtilis</td>
+          <td>B. subtilis</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/BACSU-uniprot.gaf.gz">BACSU-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/BACSU-uniprot.gpi.gz">BACSU-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Bacteroides thetaiotaomicron</td>
+          <td>Bacteroidetes bacteria</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/BACTN-uniprot.gaf.gz">BACTN-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/BACTN-uniprot.gpi.gz">BACTN-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Batrachochytrium dendrobatidis</td>
+          <td>Frog chytrid fungus</td>
+          <td>Fungi</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/BATDJ-uniprot.gaf.gz">BATDJ-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/BATDJ-uniprot.gpi.gz">BATDJ-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Bos taurus</td>
+          <td>Bovine</td>
+          <td>Vertebrates</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/BOVIN-uniprot.gaf.gz">BOVIN-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/BOVIN-uniprot.gpi.gz">BOVIN-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Brachypodium distachyon</td>
+          <td>Purple false brome</td>
+          <td>Plants</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/BRADI-uniprot.gaf.gz">BRADI-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/BRADI-uniprot.gpi.gz">BRADI-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Bradyrhizobium diazoefficiens strain JCM 10833</td>
+          <td>B. diazoefficiens strain JCM 10833</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/BRADU-uniprot.gaf.gz">BRADU-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/BRADU-uniprot.gpi.gz">BRADU-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Branchiostoma floridae</td>
+          <td>Florida lancelet (Amphioxus)</td>
+          <td>Eumetazoa</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/BRAFL-uniprot.gaf.gz">BRAFL-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/BRAFL-uniprot.gpi.gz">BRAFL-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Brassica campestris</td>
+          <td>Field mustard</td>
+          <td>Plants</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/BRACM-uniprot.gaf.gz">BRACM-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/BRACM-uniprot.gpi.gz">BRACM-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Caenorhabditis briggsae</td>
+          <td>Nematode C. briggsae</td>
+          <td>Nematodes</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CAEBR-uniprot.gaf.gz">CAEBR-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/CAEBR-uniprot.gpi.gz">CAEBR-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Campylobacter jejuni serotype O:2</td>
+          <td>Campylobacter O:2</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CAMJE-uniprot.gaf.gz">CAMJE-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/CAMJE-uniprot.gpi.gz">CAMJE-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Candida albicans</td>
+          <td>Candida</td>
+          <td>Fungi</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CANAL-mod.gaf.gz">CANAL-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CANAL-uniprot.gaf.gz">CANAL-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/CANAL-uniprot.gpi.gz">CANAL-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Candida dubliniensis</td>
+          <td>C. dubliniensis</td>
+          <td>Fungi</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CANDC-mod.gaf.gz">CANDC-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CANDC-uniprot.gaf.gz">CANDC-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/CANDC-uniprot.gpi.gz">CANDC-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Candida glabrata (strain ATCC 2001 / BCRC 20586 / JCM 3761 / NBRC 0622 / NRRL Y-65 / CBS 138) (Nakaseomyces glabratus)</td>
+          <td></td>
+          <td>Fungi</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CANGA-mod.gaf.gz">CANGA-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CANGA-uniprot.gaf.gz">CANGA-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/CANGA-uniprot.gpi.gz">CANGA-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Candida orthopsilosis (strain 90-125) (Co 90-125)</td>
+          <td></td>
+          <td>Fungi</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CANO9-mod.gaf.gz">CANO9-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CANO9-uniprot.gaf.gz">CANO9-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/CANO9-uniprot.gpi.gz">CANO9-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Candida parapsilosis (strain CDC 317 / ATCC MYA-4646)</td>
+          <td></td>
+          <td>Fungi</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CANPC-mod.gaf.gz">CANPC-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CANPC-uniprot.gaf.gz">CANPC-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/CANPC-uniprot.gpi.gz">CANPC-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Candida tropicalis (strain ATCC MYA-3404 / T1)</td>
+          <td></td>
+          <td>Fungi</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CANTT-mod.gaf.gz">CANTT-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CANTT-uniprot.gaf.gz">CANTT-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/CANTT-uniprot.gpi.gz">CANTT-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Canis lupus familiaris</td>
+          <td>Dog</td>
+          <td>Vertebrates</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CANLF-uniprot.gaf.gz">CANLF-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/CANLF-uniprot.gpi.gz">CANLF-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Chlamydia trachomatis</td>
+          <td>Chlamydia</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CHLTR-uniprot.gaf.gz">CHLTR-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/CHLTR-uniprot.gpi.gz">CHLTR-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Chlamydomonas reinhardtii</td>
+          <td>Green algae</td>
+          <td>Plants</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CHLRE-uniprot.gaf.gz">CHLRE-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/CHLRE-uniprot.gpi.gz">CHLRE-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Chloroflexus aurantiacus</td>
+          <td>Chloroflexi bacteria</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CHLAA-uniprot.gaf.gz">CHLAA-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/CHLAA-uniprot.gpi.gz">CHLAA-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Ciona intestinalis</td>
+          <td>Sea squirt</td>
+          <td>Eumetazoa</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CIOIN-uniprot.gaf.gz">CIOIN-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/CIOIN-uniprot.gpi.gz">CIOIN-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Citrobacter koseri (strain ATCC BAA-895)</td>
+          <td>C. koseri ATCC BAA-895</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CITK8-uniprot.gaf.gz">CITK8-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/CITK8-uniprot.gpi.gz">CITK8-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Clavispora lusitaniae (strain ATCC 42720)</td>
+          <td></td>
+          <td>Fungi</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CLAL4-mod.gaf.gz">CLAL4-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CLAL4-uniprot.gaf.gz">CLAL4-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/CLAL4-uniprot.gpi.gz">CLAL4-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Clostridium botulinum</td>
+          <td>C. botulinum</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CLOBH-uniprot.gaf.gz">CLOBH-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/CLOBH-uniprot.gpi.gz">CLOBH-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Coxiella burnetii</td>
+          <td>Coxiella bacteria</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/COXBU-uniprot.gaf.gz">COXBU-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/COXBU-uniprot.gpi.gz">COXBU-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Cryptococcus neoformans var. neoformans serotype D (Filobasidiella neoformans)</td>
+          <td>C. neoformans</td>
+          <td>Fungi</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CRYD1-uniprot.gaf.gz">CRYD1-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/CRYD1-uniprot.gpi.gz">CRYD1-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Danio rerio</td>
+          <td>Zebrafish</td>
+          <td>Vertebrates</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/DANRE-mod.gaf.gz">DANRE-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/DANRE-uniprot.gaf.gz">DANRE-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/DANRE-uniprot.gpi.gz">DANRE-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Daphnia pulex</td>
+          <td>Water flea</td>
+          <td>Arthropods</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/DAPPU-uniprot.gaf.gz">DAPPU-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/DAPPU-uniprot.gpi.gz">DAPPU-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Debaryomyces hansenii (strain ATCC 36239 / CBS 767 / BCRC 21394 / JCM 1990 / NBRC 0083 / IGC 2968) (Torulaspora hansenii)</td>
+          <td></td>
+          <td>Fungi</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/DEBHA-uniprot.gaf.gz">DEBHA-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/DEBHA-uniprot.gpi.gz">DEBHA-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Deinococcus radiodurans</td>
+          <td>Deinococcus bacteria</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/DEIRA-uniprot.gaf.gz">DEIRA-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/DEIRA-uniprot.gpi.gz">DEIRA-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Dictyoglomus turgidum</td>
+          <td>Dictyoglomi bacteria</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/DICTD-uniprot.gaf.gz">DICTD-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/DICTD-uniprot.gpi.gz">DICTD-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Dictyostelium discoideum</td>
+          <td>Social amoeba</td>
+          <td>Amoebozoa</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/DICDI-mod.gaf.gz">DICDI-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/DICDI-uniprot.gaf.gz">DICDI-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/DICDI-uniprot.gpi.gz">DICDI-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Dictyostelium purpureum</td>
+          <td>Slime mold</td>
+          <td>Amoebozoa</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/DICPU-uniprot.gaf.gz">DICPU-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/DICPU-uniprot.gpi.gz">DICPU-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Drosophila melanogaster</td>
+          <td>Fruit fly</td>
+          <td>Arthropods</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/DROME-mod.gaf.gz">DROME-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/DROME-uniprot.gaf.gz">DROME-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/DROME-uniprot.gpi.gz">DROME-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Emericella nidulans</td>
+          <td>E. nidulans</td>
+          <td>Fungi</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/EMENI-uniprot.gaf.gz">EMENI-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/EMENI-uniprot.gpi.gz">EMENI-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Entamoeba histolytica</td>
+          <td>Entamoeba</td>
+          <td>Amoebozoa</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/ENTH1-uniprot.gaf.gz">ENTH1-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/ENTH1-uniprot.gpi.gz">ENTH1-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Enterococcus casseliflavus EC20</td>
+          <td></td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/ENTCA-uniprot.gaf.gz">ENTCA-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/ENTCA-uniprot.gpi.gz">ENTCA-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Enterococcus faecalis (strain ATCC 700802 / V583)</td>
+          <td></td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/ENTFA-uniprot.gaf.gz">ENTFA-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/ENTFA-uniprot.gpi.gz">ENTFA-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Enterococcus gallinarum</td>
+          <td>E. gallinarum</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/ENTGA-uniprot.gaf.gz">ENTGA-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/ENTGA-uniprot.gpi.gz">ENTGA-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Equus caballus</td>
+          <td>Horse</td>
+          <td>Vertebrates</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/HORSE-uniprot.gaf.gz">HORSE-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/HORSE-uniprot.gpi.gz">HORSE-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Eremothecium gossypii</td>
+          <td>E. gossypii</td>
+          <td>Fungi</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/EREGS-uniprot.gaf.gz">EREGS-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/EREGS-uniprot.gpi.gz">EREGS-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Escherichia coli K12</td>
+          <td>E. coli K12</td>
+          <td>Bacteria</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/ECOLI-mod.gaf.gz">ECOLI-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/ECOLI-uniprot.gaf.gz">ECOLI-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/ECOLI-uniprot.gpi.gz">ECOLI-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Escherichia coli O157:H7</td>
+          <td>E. coli O157:H7</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/ECO57-uniprot.gaf.gz">ECO57-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/ECO57-uniprot.gpi.gz">ECO57-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Felis catus</td>
+          <td>Cat</td>
+          <td>Vertebrates</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/FELCA-uniprot.gaf.gz">FELCA-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/FELCA-uniprot.gpi.gz">FELCA-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Foot-and-mouth disease virus serotype O (FMDV)</td>
+          <td>FMDV</td>
+          <td>Viruses</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/FMDVO-uniprot.gaf.gz">FMDVO-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/FMDVO-uniprot.gpi.gz">FMDVO-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Fusobacterium nucleatum (strain ATCC 25586)</td>
+          <td>F. nucleatum ATCC 25586</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/FUSNN-uniprot.gaf.gz">FUSNN-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/FUSNN-uniprot.gpi.gz">FUSNN-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Gallus gallus</td>
+          <td>Chicken</td>
+          <td>Vertebrates</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CHICK-uniprot.gaf.gz">CHICK-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/CHICK-uniprot.gpi.gz">CHICK-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Geobacter sulfurreducens (strain ATCC 51573)</td>
+          <td>G. sulfurreducens strain ATCC 51573</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/GEOSL-uniprot.gaf.gz">GEOSL-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/GEOSL-uniprot.gpi.gz">GEOSL-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Giardia intestinalis</td>
+          <td>Giardia</td>
+          <td>Eukaryotes</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/GIAIC-uniprot.gaf.gz">GIAIC-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/GIAIC-uniprot.gpi.gz">GIAIC-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Gloeobacter violaceus</td>
+          <td>Cyanobacteria G. violaceus</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/GLOVI-uniprot.gaf.gz">GLOVI-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/GLOVI-uniprot.gpi.gz">GLOVI-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Glycine max</td>
+          <td>Soybean</td>
+          <td>Plants</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/SOYBN-uniprot.gaf.gz">SOYBN-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/SOYBN-uniprot.gpi.gz">SOYBN-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Gorilla gorilla gorilla</td>
+          <td>Gorilla</td>
+          <td>Vertebrates</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/GORGO-uniprot.gaf.gz">GORGO-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/GORGO-uniprot.gpi.gz">GORGO-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Gossypium hirsutum</td>
+          <td>Upland cotton</td>
+          <td>Vertebrates</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/GOSHI-uniprot.gaf.gz">GOSHI-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/GOSHI-uniprot.gpi.gz">GOSHI-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Haemophilus influenzae (strain ATCC 51907 / DSM 11121 / KW20 / Rd)</td>
+          <td>H. influenzae strain ATCC 51907</td>
+          <td>Viruses</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/HAEIN-uniprot.gaf.gz">HAEIN-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/HAEIN-uniprot.gpi.gz">HAEIN-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Halalkalibacterium halodurans (strain ATCC BAA-125 / DSM 18197 / FERM 7344 / JCM 9153 / C-125) (Bacillus halodurans)</td>
+          <td></td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/HALH5-uniprot.gaf.gz">HALH5-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/HALH5-uniprot.gpi.gz">HALH5-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Halobacterium salinarum (strain ATCC 700922)</td>
+          <td>H. salinarum strain ATCC 700922</td>
+          <td>Archaea</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/HALSA-uniprot.gaf.gz">HALSA-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/HALSA-uniprot.gpi.gz">HALSA-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Helianthus annuus</td>
+          <td>Common sunflower</td>
+          <td>Plants</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/HELAN-uniprot.gaf.gz">HELAN-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/HELAN-uniprot.gpi.gz">HELAN-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Helicobacter pylori (Campylobacter pylori) strain ATCC 700392 / 26695</td>
+          <td>H. pylori</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/HELPY-uniprot.gaf.gz">HELPY-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/HELPY-uniprot.gpi.gz">HELPY-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Helobdella robusta</td>
+          <td>Leech</td>
+          <td>Eumetazoa</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/HELRO-uniprot.gaf.gz">HELRO-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/HELRO-uniprot.gpi.gz">HELRO-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Hepatitis B virus genotype C subtype ayr (isolate Human/Japan/Okamoto/-)</td>
+          <td>HBV-C</td>
+          <td>Viruses</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/HBVCJ-uniprot.gaf.gz">HBVCJ-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/HBVCJ-uniprot.gpi.gz">HBVCJ-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Hepatitis C virus genotype 1a (isolate H77)</td>
+          <td>HCV</td>
+          <td>Viruses</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/HCV77-uniprot.gaf.gz">HCV77-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/HCV77-uniprot.gpi.gz">HCV77-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Homo sapiens</td>
+          <td>Human</td>
+          <td>Vertebrates</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/HUMAN-uniprot.gaf.gz">HUMAN-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/HUMAN-uniprot.gpi.gz">HUMAN-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Hordeum vulgare subsp. vulgare</td>
+          <td>Domesticated barley</td>
+          <td>Plants</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/HORVV-uniprot.gaf.gz">HORVV-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/HORVV-uniprot.gpi.gz">HORVV-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Human cytomegalovirus (Human herpesvirus 5) strain Merlin</td>
+          <td>HHV-5 Merlin</td>
+          <td>Viruses</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/HCMVM-uniprot.gaf.gz">HCMVM-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/HCMVM-uniprot.gpi.gz">HCMVM-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Human cytomegalovirus (strain AD169)</td>
+          <td>Human herpesvirus 5 (HHV-5)</td>
+          <td>Viruses</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/HCMVA-uniprot.gaf.gz">HCMVA-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/HCMVA-uniprot.gpi.gz">HCMVA-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Human herpesvirus 1 (strain 17)</td>
+          <td>Human herpes simplex virus 1 (HHV-1)</td>
+          <td>Viruses</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/HHV11-uniprot.gaf.gz">HHV11-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/HHV11-uniprot.gpi.gz">HHV11-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Human immunodeficiency virus type 1 group O (isolate ANT70)</td>
+          <td>HIV-1</td>
+          <td>Viruses</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/HV1AN-uniprot.gaf.gz">HV1AN-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/HV1AN-uniprot.gpi.gz">HV1AN-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Human papillomavirus type 16</td>
+          <td>HPV</td>
+          <td>Viruses</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/HPV16-uniprot.gaf.gz">HPV16-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/HPV16-uniprot.gpi.gz">HPV16-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Ixodes scapularis</td>
+          <td>Deer tick</td>
+          <td>Arthropods</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/IXOSC-uniprot.gaf.gz">IXOSC-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/IXOSC-uniprot.gpi.gz">IXOSC-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Juglans regia</td>
+          <td>English walnut</td>
+          <td>Plants</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/JUGRE-uniprot.gaf.gz">JUGRE-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/JUGRE-uniprot.gpi.gz">JUGRE-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Klebsiella pneumoniae subsp. ozaenae (subspecies)</td>
+          <td>Bacillus ozaenae</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/KLEPO-uniprot.gaf.gz">KLEPO-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/KLEPO-uniprot.gpi.gz">KLEPO-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Klebsiella pneumoniae subsp. pneumoniae (strain HS11286)</td>
+          <td>Bacillus pneumoniae</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/KLEPH-uniprot.gaf.gz">KLEPH-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/KLEPH-uniprot.gpi.gz">KLEPH-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Klebsormidium nitens</td>
+          <td>Green algae</td>
+          <td>Plants</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/KLENI-uniprot.gaf.gz">KLENI-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/KLENI-uniprot.gpi.gz">KLENI-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Korarchaeum cryptofilum</td>
+          <td>Korarchaeote</td>
+          <td>Archaea</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/KORCO-uniprot.gaf.gz">KORCO-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/KORCO-uniprot.gpi.gz">KORCO-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Lactuca sativa</td>
+          <td>Garden lettuce</td>
+          <td>Plants</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/LACSA-uniprot.gaf.gz">LACSA-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/LACSA-uniprot.gpi.gz">LACSA-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Leishmania major</td>
+          <td>Leishmania</td>
+          <td>Eukaryotes</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/LEIMA-uniprot.gaf.gz">LEIMA-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/LEIMA-uniprot.gpi.gz">LEIMA-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Lepisosteus oculatus</td>
+          <td>Spotted gar</td>
+          <td>Vertebrates</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/LEPOC-uniprot.gaf.gz">LEPOC-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/LEPOC-uniprot.gpi.gz">LEPOC-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Leptospira interrogans</td>
+          <td>Spirochaetes bacteria</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/LEPIN-uniprot.gaf.gz">LEPIN-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/LEPIN-uniprot.gpi.gz">LEPIN-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Listeria monocytogenes serovar 1/2a (strain ATCC BAA-679 / EGD-e)</td>
+          <td>Listeria</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/LISMO-uniprot.gaf.gz">LISMO-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/LISMO-uniprot.gpi.gz">LISMO-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Lodderomyces elongisporus (strain ATCC 11503 / CBS 2605 / JCM 1781 / NBRC 1676 / NRRL YB-4239) (Saccharomyces elongisporus)</td>
+          <td></td>
+          <td>Fungi</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/LODEL-uniprot.gaf.gz">LODEL-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/LODEL-uniprot.gpi.gz">LODEL-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Macaca mulatta</td>
+          <td>Rhesus macaque</td>
+          <td>Vertebrates</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/MACMU-uniprot.gaf.gz">MACMU-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/MACMU-uniprot.gpi.gz">MACMU-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Manihot esculenta</td>
+          <td>Cassava</td>
+          <td>Plants</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/MANES-uniprot.gaf.gz">MANES-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/MANES-uniprot.gpi.gz">MANES-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Marchantia polymorpha</td>
+          <td>Liverwort</td>
+          <td>Plants</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/MARPO-uniprot.gaf.gz">MARPO-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/MARPO-uniprot.gpi.gz">MARPO-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Measles virus (Subacute sclerose panencephalitis virus) strain Ichinose-B95a</td>
+          <td>MeV strain Ichinose-B95a</td>
+          <td>Viruses</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/MEASC-uniprot.gaf.gz">MEASC-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/MEASC-uniprot.gpi.gz">MEASC-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Medicago truncatula</td>
+          <td>Barrel medic</td>
+          <td>Plants</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/MEDTR-uniprot.gaf.gz">MEDTR-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/MEDTR-uniprot.gpi.gz">MEDTR-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Methanocaldococcus jannaschii</td>
+          <td>Methanococci archaea</td>
+          <td>Archaea</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/METJA-uniprot.gaf.gz">METJA-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/METJA-uniprot.gpi.gz">METJA-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Methanosarcina acetivorans</td>
+          <td>M. acetivorans</td>
+          <td>Archaea</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/METAC-uniprot.gaf.gz">METAC-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/METAC-uniprot.gpi.gz">METAC-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Meyerozyma guilliermondii (strain ATCC 6260 / CBS 566 / DSM 6381 / JCM 1539 / NBRC 10279 / NRRL Y-324) (Candida guilliermondii)</td>
+          <td>Candida guilliermondii</td>
+          <td>Fungi</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/PICGU-uniprot.gaf.gz">PICGU-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/PICGU-uniprot.gpi.gz">PICGU-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Monodelphis domestica</td>
+          <td>Gray short-tailed opossum</td>
+          <td>Vertebrates</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/MONDO-uniprot.gaf.gz">MONDO-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/MONDO-uniprot.gpi.gz">MONDO-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Monosiga brevicollis</td>
+          <td>Choanoflagellate</td>
+          <td>Eukaryotes</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/MONBE-uniprot.gaf.gz">MONBE-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/MONBE-uniprot.gpi.gz">MONBE-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Mus musculus</td>
+          <td>Mouse</td>
+          <td>Vertebrates</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/MOUSE-mod.gaf.gz">MOUSE-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/MOUSE-uniprot.gaf.gz">MOUSE-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/MOUSE-uniprot.gpi.gz">MOUSE-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Mycobacterium tuberculosis (strain ATCC 25177 / H37Ra)</td>
+          <td>Mycobacterium sp. H37Ra</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/MYCTA-uniprot.gaf.gz">MYCTA-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/MYCTA-uniprot.gpi.gz">MYCTA-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Mycobacterium tuberculosis (strain ATCC 25618 / H37Rv)</td>
+          <td>Mycobacterium sp. H37Rv</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/MYCTU-uniprot.gaf.gz">MYCTU-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/MYCTU-uniprot.gpi.gz">MYCTU-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Mycoplasma genitalium G37</td>
+          <td>M. genitalium G37</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/MYCGE-uniprot.gaf.gz">MYCGE-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/MYCGE-uniprot.gpi.gz">MYCGE-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Mycoplasma pneumoniae strain ATCC 29342 / M129 / Subtype 1</td>
+          <td></td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/MYCPN-uniprot.gaf.gz">MYCPN-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/MYCPN-uniprot.gpi.gz">MYCPN-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Mycosarcoma maydis (Ustilago maydis)</td>
+          <td>Corn smut fungus</td>
+          <td>Fungi</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/MYCMD-uniprot.gaf.gz">MYCMD-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/MYCMD-uniprot.gpi.gz">MYCMD-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Neisseria meningitidis serogroup B (strain ATCC BAA-335 / MC58)</td>
+          <td>betaproteobacteria</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/NEIMB-uniprot.gaf.gz">NEIMB-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/NEIMB-uniprot.gpi.gz">NEIMB-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Nelumbo nucifera</td>
+          <td>Sacred lotus</td>
+          <td>Plants</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/NELNU-uniprot.gaf.gz">NELNU-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/NELNU-uniprot.gpi.gz">NELNU-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Nematode C. elegans</td>
+          <td>Nematode C. elegans</td>
+          <td>Nematodes</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CAEEL-mod.gaf.gz">CAEEL-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/CAEEL-uniprot.gaf.gz">CAEEL-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/CAEEL-uniprot.gpi.gz">CAEEL-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Nematostella vectensis</td>
+          <td>Starlet sea anemone</td>
+          <td>Eumetazoa</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/NEMVE-uniprot.gaf.gz">NEMVE-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/NEMVE-uniprot.gpi.gz">NEMVE-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Neurospora crassa</td>
+          <td>Neurospora</td>
+          <td>Fungi</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/NEUCR-uniprot.gaf.gz">NEUCR-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/NEUCR-uniprot.gpi.gz">NEUCR-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Nicotiana tabacum</td>
+          <td>Tobacco</td>
+          <td>Plants</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/TOBAC-uniprot.gaf.gz">TOBAC-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/TOBAC-uniprot.gpi.gz">TOBAC-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Nitrosopumilus maritimus (strain SCM1)</td>
+          <td>N. maritimus SCM1</td>
+          <td>Archaea</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/NITMS-uniprot.gaf.gz">NITMS-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/NITMS-uniprot.gpi.gz">NITMS-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Ornithorhynchus anatinus</td>
+          <td>Duckbill platypus</td>
+          <td>Vertebrates</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/ORNAN-uniprot.gaf.gz">ORNAN-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/ORNAN-uniprot.gpi.gz">ORNAN-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Oryza sativa</td>
+          <td>Rice</td>
+          <td>Plants</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/ORYSJ-uniprot.gaf.gz">ORYSJ-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/ORYSJ-uniprot.gpi.gz">ORYSJ-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Oryzias latipes</td>
+          <td>Japanese rice fish</td>
+          <td>Vertebrates</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/ORYLA-uniprot.gaf.gz">ORYLA-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/ORYLA-uniprot.gpi.gz">ORYLA-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Pan troglodytes</td>
+          <td>Chimpanzee</td>
+          <td>Vertebrates</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/PANTR-uniprot.gaf.gz">PANTR-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/PANTR-uniprot.gpi.gz">PANTR-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Paramecium tetraurelia</td>
+          <td>Alveolate paramecium</td>
+          <td>Eukaryotes</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/PARTE-uniprot.gaf.gz">PARTE-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/PARTE-uniprot.gpi.gz">PARTE-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Phaeosphaeria nodorum</td>
+          <td>Glume blotch fungus</td>
+          <td>Fungi</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/PHANO-uniprot.gaf.gz">PHANO-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/PHANO-uniprot.gpi.gz">PHANO-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Physcomitrella patens</td>
+          <td>Spreading earth moss</td>
+          <td>Plants</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/PHYPA-uniprot.gaf.gz">PHYPA-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/PHYPA-uniprot.gpi.gz">PHYPA-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Phytophthora ramorum</td>
+          <td>Sudden oak death agent</td>
+          <td>Oomycetes</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/PHYRM-uniprot.gaf.gz">PHYRM-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/PHYRM-uniprot.gpi.gz">PHYRM-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Plasmodium falciparum (isolate 3D7)</td>
+          <td>Plasmodium</td>
+          <td>Eukaryotes</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/PLAF7-uniprot.gaf.gz">PLAF7-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/PLAF7-uniprot.gpi.gz">PLAF7-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Populus trichocarpa</td>
+          <td>Black cottonwood</td>
+          <td>Plants</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/POPTR-uniprot.gaf.gz">POPTR-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/POPTR-uniprot.gpi.gz">POPTR-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Pristionchus pacificus</td>
+          <td>Parasitic nematode worm</td>
+          <td>Nematodes</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/PRIPA-uniprot.gaf.gz">PRIPA-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/PRIPA-uniprot.gpi.gz">PRIPA-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Prunus persica</td>
+          <td>Peach</td>
+          <td>Plants</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/PRUPE-uniprot.gaf.gz">PRUPE-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/PRUPE-uniprot.gpi.gz">PRUPE-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Pseudomonas aeruginosa (strain ATCC 15692 / PAO1)</td>
+          <td>Pseudomonas sp. PAO1</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/PSEAE-uniprot.gaf.gz">PSEAE-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/PSEAE-uniprot.gpi.gz">PSEAE-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Puccinia graminis</td>
+          <td>Black stem rust fungus</td>
+          <td>Fungi</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/PUCGT-uniprot.gaf.gz">PUCGT-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/PUCGT-uniprot.gpi.gz">PUCGT-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Pyrobaculum aerophilum (strain ATCC 51768 / IM2)</td>
+          <td>Pyrobaculum aerophilum IM2</td>
+          <td>Archaea</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/PYRAE-uniprot.gaf.gz">PYRAE-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/PYRAE-uniprot.gpi.gz">PYRAE-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Rattus norvegicus</td>
+          <td>Rat</td>
+          <td>Vertebrates</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/RAT-mod.gaf.gz">RAT-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/RAT-uniprot.gaf.gz">RAT-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/RAT-uniprot.gpi.gz">RAT-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Rhodopirellula baltica (strain SH1)</td>
+          <td>Pirellula sp. 1</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/RHOBA-uniprot.gaf.gz">RHOBA-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/RHOBA-uniprot.gpi.gz">RHOBA-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Saccharolobus solfataricus</td>
+          <td>Sulfolobus solfataricus P2</td>
+          <td>Archaea</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/SACS2-uniprot.gaf.gz">SACS2-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/SACS2-uniprot.gpi.gz">SACS2-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Saccharomyces cerevisiae</td>
+          <td>"Baker's yeast"</td>
+          <td>Fungi</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/YEAST-mod.gaf.gz">YEAST-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/YEAST-uniprot.gaf.gz">YEAST-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/YEAST-uniprot.gpi.gz">YEAST-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Salmonella typhimurium (strain LT2 / SGSC1412 / ATCC 700720)</td>
+          <td>S. typhimurium LT2</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/SALTY-uniprot.gaf.gz">SALTY-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/SALTY-uniprot.gpi.gz">SALTY-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Schizosaccharomyces japonicus</td>
+          <td>Fission yeast</td>
+          <td>Fungi</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/SCHJY-mod.gaf.gz">SCHJY-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/SCHJY-uniprot.gaf.gz">SCHJY-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/SCHJY-uniprot.gpi.gz">SCHJY-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Schizosaccharomyces pombe</td>
+          <td>Fission yeast</td>
+          <td>Fungi</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/SCHPO-mod.gaf.gz">SCHPO-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/SCHPO-uniprot.gaf.gz">SCHPO-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/SCHPO-uniprot.gpi.gz">SCHPO-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Sclerotinia sclerotiorum</td>
+          <td>White mold</td>
+          <td>Fungi</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/SCLS1-uniprot.gaf.gz">SCLS1-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/SCLS1-uniprot.gpi.gz">SCLS1-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Shewanella oneidensis (strain ATCC 700550 / MR-1)</td>
+          <td>Shewanella sp. MR-1</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/SHEON-uniprot.gaf.gz">SHEON-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/SHEON-uniprot.gpi.gz">SHEON-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Shigella flexneri</td>
+          <td>Shigella paradysenteriae</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/SHIFL-uniprot.gaf.gz">SHIFL-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/SHIFL-uniprot.gpi.gz">SHIFL-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Solanum lycopersicum</td>
+          <td>Tomato</td>
+          <td>Plants</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/SOLLC-uniprot.gaf.gz">SOLLC-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/SOLLC-uniprot.gpi.gz">SOLLC-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Sorghum bicolor</td>
+          <td>Sorghum</td>
+          <td>Plants</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/SORBI-uniprot.gaf.gz">SORBI-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/SORBI-uniprot.gpi.gz">SORBI-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Spinacia oleracea</td>
+          <td>Spinach</td>
+          <td>Plants</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/SPIOL-uniprot.gaf.gz">SPIOL-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/SPIOL-uniprot.gpi.gz">SPIOL-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Staphylococcus aureus (strain NCTC 8325 / PS 47)</td>
+          <td>S. aureus NCTC 8325</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/STAA8-uniprot.gaf.gz">STAA8-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/STAA8-uniprot.gpi.gz">STAA8-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Streptococcus pneumoniae (strain ATCC BAA-255 / R6)</td>
+          <td>S. pneumoniae R6</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/STRR6-uniprot.gaf.gz">STRR6-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/STRR6-uniprot.gpi.gz">STRR6-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Streptococcus pneumoniae serotype 2 (strain D39 / NCTC 7466)</td>
+          <td>S. pneumoniae D39</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/STRP2-uniprot.gaf.gz">STRP2-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/STRP2-uniprot.gpi.gz">STRP2-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Streptococcus pneumoniae serotype 4 (strain ATCC BAA-334 / TIGR4)</td>
+          <td>S. pneumoniae TIGR4</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/STRPN-uniprot.gaf.gz">STRPN-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/STRPN-uniprot.gpi.gz">STRPN-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Streptococcus pyogenes serotype M1</td>
+          <td>Streptococcus</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/STRP1-uniprot.gaf.gz">STRP1-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/STRP1-uniprot.gpi.gz">STRP1-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Streptomyces clavuligerus</td>
+          <td>S. clavuligerus</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/STRCL-uniprot.gaf.gz">STRCL-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/STRCL-uniprot.gpi.gz">STRCL-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Streptomyces coelicolor Streptomyces coelicolor (strain ATCC BAA-471 / A3(2))</td>
+          <td>Streptomyces coelicolor A3(2)</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/STRCO-uniprot.gaf.gz">STRCO-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/STRCO-uniprot.gpi.gz">STRCO-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Strongylocentrotus purpuratus</td>
+          <td>Purple sea urchin</td>
+          <td>Eumetazoa</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/STRPU-uniprot.gaf.gz">STRPU-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/STRPU-uniprot.gpi.gz">STRPU-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Sus scrofa</td>
+          <td>Pig</td>
+          <td>Vertebrates</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/PIG-uniprot.gaf.gz">PIG-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/PIG-uniprot.gpi.gz">PIG-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Synechocystis sp.</td>
+          <td>Synechocystis cyanobacteria</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/SYNY3-uniprot.gaf.gz">SYNY3-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/SYNY3-uniprot.gpi.gz">SYNY3-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Thalassiosira pseudonana</td>
+          <td>Marine diatom</td>
+          <td>Eukaryotes</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/THAPS-uniprot.gaf.gz">THAPS-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/THAPS-uniprot.gpi.gz">THAPS-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Theobroma cacao</td>
+          <td>Cocoa</td>
+          <td>Plants</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/THECC-uniprot.gaf.gz">THECC-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/THECC-uniprot.gpi.gz">THECC-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Thermococcus kodakaraensis</td>
+          <td>Pyrococcus sp. KOD1  (strain ATCC BAA-918 / KOD1)</td>
+          <td>Archaea</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/THEKO-uniprot.gaf.gz">THEKO-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/THEKO-uniprot.gpi.gz">THEKO-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Thermodesulfovibrio yellowstonii</td>
+          <td>Nitrospirae bacteria</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/THEYD-uniprot.gaf.gz">THEYD-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/THEYD-uniprot.gpi.gz">THEYD-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Thermotoga maritima</td>
+          <td>Thermotogae bacteria</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/THEMA-uniprot.gaf.gz">THEMA-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/THEMA-uniprot.gpi.gz">THEMA-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Tribolium castaneum</td>
+          <td>Red flour beetle</td>
+          <td>Arthropods</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/TRICA-uniprot.gaf.gz">TRICA-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/TRICA-uniprot.gpi.gz">TRICA-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Trichomonas vaginalis</td>
+          <td>T. vaginalis</td>
+          <td>Eukaryotes</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/TRIV3-uniprot.gaf.gz">TRIV3-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/TRIV3-uniprot.gpi.gz">TRIV3-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Trichoplax adhaerens</td>
+          <td>Trichoplax reptans</td>
+          <td>Eumetazoa</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/TRIAD-uniprot.gaf.gz">TRIAD-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/TRIAD-uniprot.gpi.gz">TRIAD-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Triticum aestivum</td>
+          <td>Wheat</td>
+          <td>Plants</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/WHEAT-uniprot.gaf.gz">WHEAT-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/WHEAT-uniprot.gpi.gz">WHEAT-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Trypanosoma brucei</td>
+          <td>T. brucei TREU927</td>
+          <td>Eukaryotes</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/TRYB2-uniprot.gaf.gz">TRYB2-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/TRYB2-uniprot.gpi.gz">TRYB2-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Vaccinia virus (strain Western Reserve)</td>
+          <td>VACV strain WR</td>
+          <td>Viruses</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/VACCW-uniprot.gaf.gz">VACCW-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/VACCW-uniprot.gpi.gz">VACCW-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Varicella-zoster virus (Human herpesvirus 3) strain Dumas</td>
+          <td>HHV-3 strain Dumas</td>
+          <td>Viruses</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/VZVD-uniprot.gaf.gz">VZVD-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/VZVD-uniprot.gpi.gz">VZVD-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Variola virus (Smallpox virus) (isolate Human/India/Ind3/1967)</td>
+          <td>VARV</td>
+          <td>Viruses</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/VAR67-uniprot.gaf.gz">VAR67-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/VAR67-uniprot.gpi.gz">VAR67-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Vibrio cholerae</td>
+          <td>V. cholera</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/VIBCH-uniprot.gaf.gz">VIBCH-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/VIBCH-uniprot.gpi.gz">VIBCH-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Vitis vinifera</td>
+          <td>Grape</td>
+          <td>Plants</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/VITVI-uniprot.gaf.gz">VITVI-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/VITVI-uniprot.gpi.gz">VITVI-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Xanthomonas campestris</td>
+          <td>X. campestris</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/XANCP-uniprot.gaf.gz">XANCP-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/XANCP-uniprot.gpi.gz">XANCP-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Xenopus laevis</td>
+          <td>African clawed frog</td>
+          <td>Vertebrates</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/XENLA-mod.gaf.gz">XENLA-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/XENLA-uniprot.gaf.gz">XENLA-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/XENLA-uniprot.gpi.gz">XENLA-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Xenopus tropicalis</td>
+          <td>Western clawed frog</td>
+          <td>Vertebrates</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/XENTR-mod.gaf.gz">XENTR-mod.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/XENTR-uniprot.gaf.gz">XENTR-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/XENTR-uniprot.gpi.gz">XENTR-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Yarrowia lipolytica</td>
+          <td>Y. lipolytica yeast</td>
+          <td>Fungi</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/YARLI-uniprot.gaf.gz">YARLI-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/YARLI-uniprot.gpi.gz">YARLI-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Yersinia pestis</td>
+          <td>Plague bacteria</td>
+          <td>Bacteria</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/YERPE-uniprot.gaf.gz">YERPE-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/YERPE-uniprot.gpi.gz">YERPE-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Zea mays</td>
+          <td>Maize</td>
+          <td>Plants</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/MAIZE-uniprot.gaf.gz">MAIZE-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/MAIZE-uniprot.gpi.gz">MAIZE-uniprot.gpi.gz</a></td>
+        </tr>
+        <tr>
+          <td>Zika virus</td>
+          <td>ZIKV</td>
+          <td>Viruses</td>
+          <td>&mdash;</td>
+          <td><a href="https://current.geneontology.org/annotations/gaf/ZIKV-uniprot.gaf.gz">ZIKV-uniprot.gaf.gz</a></td>
+          <td><a href="https://current.geneontology.org/annotations/gpi/ZIKV-uniprot.gpi.gz">ZIKV-uniprot.gpi.gz</a></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <script>
+  function filterSpecies() {
+    var q = document.getElementById('species-filter').value.toLowerCase();
+    var rows = document.querySelectorAll('#all-organisms-table tbody tr');
+    rows.forEach(function (row) {
+      row.style.display = (row.textContent.toLowerCase().indexOf(q) !== -1) ? '' : 'none';
+    });
+  }
+  </script>
+</div>
+
+<style>
+  .container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 20px;
+  }
+
+  h1 {
+    margin-bottom: 30px;
+  }
+
+  h2 {
+    margin-top: 30px;
+    margin-bottom: 15px;
+    font-size: 1.5em;
+  }
+
+  p {
+    margin-bottom: 20px;
+    color: #666;
+    line-height: 1.6;
+  }
+
+  .table-responsive {
+    overflow-x: auto;
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 20px;
+  }
+
+  th {
+    background-color: #f8f9fa;
+    font-weight: bold;
+    text-align: left;
+    padding: 12px;
+    border-bottom: 2px solid #dee2e6;
+    position: sticky;
+    top: 0;
+  }
+
+  td {
+    padding: 10px 12px;
+    border-bottom: 1px solid #dee2e6;
+  }
+
+  tr:hover {
+    background-color: #f8f9fa;
+  }
+
+  a {
+    color: #007bff;
+    text-decoration: none;
+  }
+
+  a:hover {
+    text-decoration: underline;
+  }
+</style>

--- a/_docs/download-go-annotations.md
+++ b/_docs/download-go-annotations.md
@@ -15,7 +15,7 @@ redirect_from:
 
 This page has instructions for getting GO annotations for almost any organism. If your organism is not available from these main sources:
 
-* <i class="fa fa-download"></i> **[Official GO products](http://current.geneontology.org/products/pages/downloads.html)**
+* <i class="fa fa-download"></i> **[Official GO products](/docs/download-go-annotations/downloads/)**
 * <i class="fa fa-external-link"></i> **[UniProt GAFs by proteome](https://ftp.ebi.ac.uk/pub/databases/GO/goa/proteomes/){:target="_blank"}**  
 * <i class="fa fa-external-link"></i> **[NCBI RefSeq](https://ftp.ncbi.nlm.nih.gov/genomes/refseq/){:target="_blank"}**
 
@@ -42,7 +42,7 @@ To ensure reproducibility for any publication where GO was used at any point in 
 * the ontology version number
 
 ### 1. Commonly studied organisms
-<i class="fa fa-download"></i> **[Download GAF annotation files for commonly-studied species](http://current.geneontology.org/products/pages/downloads.html)**
+<i class="fa fa-download"></i> **[Download GAF annotation files for commonly-studied species](/docs/download-go-annotations/downloads/)**
 
 For organisms with many expert-curated GO annotations (those with MODs, dedicated databases, etc.), we recommend downloading annotations from the links in the above-linked table. These organisms often have a large number of manual annotations supported by direct experimental evidence as well as annotations based on other evidence types.
 <!-- * Most of these have two downloads available, one with the full set of GO annotations, and one with only the “core” function annotations (PAN-GO) for each organism. /-->

--- a/_docs/faq.md
+++ b/_docs/faq.md
@@ -474,11 +474,11 @@ FAQ tags: 
 [general](/faq-tags/general)
 {:/comment}
 
-Annotations from GO Consortium member groups can be [downloaded here](http://current.geneontology.org/products/pages/downloads.html){:target="blank"}.  These are taxon-specific, although some have multiple taxons in the file.  For example, the [CGD GAF](http://current.geneontology.org/annotations/cgd.gaf.gz) includes several *Candida* as well as *Debaryomyces hansenii* and *Lodderomyces elongisporus*.
+Annotations from GO Consortium member groups can be [downloaded here](/docs/download-go-annotations/downloads/).  These are taxon-specific, although some have multiple taxons in the file.  For example, the [CGD GAF](http://current.geneontology.org/annotations/cgd.gaf.gz) includes several *Candida* as well as *Debaryomyces hansenii* and *Lodderomyces elongisporus*.
 
 If your organism is included in a multi-organism file, and you would like to extract just your organism of interest, you can filter by taxon.  [Verify your taxon ID](https://www.uniprot.org/help/taxonomy){:target="blank"} and refer to the [file format guides](/docs/go-annotations/#types-of-go-annotation-files) under "Types of GO annotation files" to determine which column to sort on.
 
-If your organism is not available from our [downloads page](http://current.geneontology.org/products/pages/downloads.html){:target="blank"}, you can [use AmiGO](http://amigo.geneontology.org/amigo/search/annotation){:target="blank"} to view or download annotations.  Filter for your taxon under "Organism"; [AmiGO](http://amigo.geneontology.org/amigo/search/annotation){:target="blank"} allows users to download up to 100,000 annotations.  [QuickGO](https://www.ebi.ac.uk/QuickGO/annotations){:target="blank"} is EMBL-EBI's GO browser and has a download limit of 2,000,000.
+If your organism is not available from our [downloads page](/docs/download-go-annotations/downloads/), you can [use AmiGO](http://amigo.geneontology.org/amigo/search/annotation){:target="blank"} to view or download annotations.  Filter for your taxon under "Organism"; [AmiGO](http://amigo.geneontology.org/amigo/search/annotation){:target="blank"} allows users to download up to 100,000 annotations.  [QuickGO](https://www.ebi.ac.uk/QuickGO/annotations){:target="blank"} is EMBL-EBI's GO browser and has a download limit of 2,000,000.
 Please see our FAQ on [AmiGO and QuickGO data](/docs/faq/#what-are-the-differences-between-the-data-available-in-amigo-and-those-on-quickgo), [software to browse the GO](/docs/faq/#where-can-i-find-software-to-allow-me-to-browse-the-go-terms-and-annotations) and [finding species that are not available in AmiGO](/docs/faq/#how-do-i-find-all-annotations-for-species-x-that-i-cant-find-in-amigo).
 
 

--- a/scripts/update_downloads.py
+++ b/scripts/update_downloads.py
@@ -91,7 +91,9 @@ def generate_table_row(org, code):
     # pipeline publishes SPECIES-{uniprot,mod}.<ext>.gz under
     # annotations/{gaf,gpad,gpi}/. Every species has a -uniprot variant;
     # only MOD-managed species (goex.yaml group != UniProt) also get -mod.
-    base = 'https://skyhook.geneontology.io/pipeline-from-goa/main/annotations'
+    # Link to current.geneontology.org -- THE canonical source of truth for a
+    # release (not the rolling skyhook build, not EBI upstream).
+    base = 'https://current.geneontology.org/annotations'
     is_mod = bool(org.get('group')) and org.get('group') != 'UniProt'
 
     if is_mod:
@@ -202,12 +204,14 @@ def generate_tables(organisms):
     return common_table + all_table
 
 
-def generate_downloads_html(new_tables, output_file='downloads.html'):
-    """Generate complete downloads.html file"""
+def generate_downloads_html(new_tables,
+                            output_file='_docs/download-go-annotations-downloads.html'):
+    """Generate the Jekyll downloads page served at
+    /docs/download-go-annotations/downloads/ (run from the repo root)."""
 
     html_content = f'''---
-layout: default
-title: Downloads
+title: Download annotations by organism
+permalink: /docs/download-go-annotations/downloads/
 ---
 
 <div class="container">


### PR DESCRIPTION
## What

- New in-site page at **`/docs/download-go-annotations/downloads/`** (generated by `scripts/update_downloads.py`, committed as `_docs/download-go-annotations-downloads.html`), replacing the standalone `downloads.html` output.
- Table links now point at **`current.geneontology.org/annotations/{gaf,gpi}/`** — the canonical source of truth for a release (was the rolling `skyhook` build after #929).
- Repoint the internal links that referenced the old `current.geneontology.org/products/pages/downloads.html` (`_docs/download-go-annotations.md` ×2, `_docs/faq.md` ×2) to the new in-site page.

## Why

`current.geneontology.org` is the canonical post-release source. The page now lives in exactly one place (this site); the old `products/pages/downloads.html` URL becomes a thin redirect to it (a separate infra step, after this deploys).

## Follow-ups (tracked separately)

Wire `update_downloads.py` into the build (or document manual regen-on-`goex.yaml`-change), consider a CloudFront 301 vs the meta-refresh redirect, styling polish against `layout: docs`, and eventual retirement of the old path. Relates to geneontology/pipeline-from-goa#396.

_— Posted by Claude Code agent on behalf of @kltm._
