### PR TITLE
Downloads page: key MOD column on goex mod_id_space (not group)

### DIFF
--- a/scripts/update_downloads.py
+++ b/scripts/update_downloads.py
@@ -90,11 +90,17 @@ def generate_table_row(org, code):
     # As of the EBI GOEx filename simplification (go-site#2681) the
     # pipeline publishes SPECIES-{uniprot,mod}.<ext>.gz under
     # annotations/{gaf,gpad,gpi}/. Every species has a -uniprot variant;
-    # only MOD-managed species (goex.yaml group != UniProt) also get -mod.
+    # only species whose gene products use a MOD ID space also get a -mod file.
+    # Key that off goex.yaml `mod_id_space` (the required gene-product namespace):
+    # != UniProtKB <=> a -mod file exists. `group` (the annotation authority) is
+    # NOT a reliable proxy -- a CGD-authority species can still be UniProtKB-only
+    # (empty/absent -mod), which made group over-emit broken -mod links for
+    # CANO9/CANTT/CLAL4/PICGU (go-site#2711, #2713). goex.yaml is the source of
+    # truth here -- no file cross-check.
     # Link to current.geneontology.org -- THE canonical source of truth for a
     # release (not the rolling skyhook build, not EBI upstream).
     base = 'https://current.geneontology.org/annotations'
-    is_mod = bool(org.get('group')) and org.get('group') != 'UniProt'
+    is_mod = (org.get('mod_id_space') or 'UniProtKB') != 'UniProtKB'
 
     if is_mod:
         mod_cell = (f'<a href="{base}/gaf/{code}-mod.gaf.gz">'
@@ -123,11 +129,10 @@ def generate_tables(organisms):
     organisms_sorted = sorted(organisms, key=lambda x: x.get('full_name', ''))
 
     # "Common Model Organisms" = every MOD-managed species (goex.yaml
-    # group != UniProt -- i.e. the ones that also get a -mod file), plus HUMAN.
-    # HUMAN is listed first; the rest keep the by-full_name order.
+    # mod_id_space != UniProtKB -- i.e. the ones that also get a -mod file), plus
+    # HUMAN. HUMAN is listed first; the rest keep the by-full_name order.
     def is_mod(org):
-        grp = org.get('group', '')
-        return bool(grp) and grp != 'UniProt'
+        return (org.get('mod_id_space') or 'UniProtKB') != 'UniProtKB'
 
     common_orgs = [o for o in organisms
                    if is_mod(o) or o.get('code_uniprot', '') == 'HUMAN']


### PR DESCRIPTION
## What
Key the "MOD ID-centric File" column on goex.yaml **`mod_id_space`** instead of **`group`** (both the per-row `-mod` cell and the "Common Model Organisms" selection):
```python
is_mod = (org.get('mod_id_space') or 'UniProtKB') != 'UniProtKB'   # was: group != 'UniProt'
```

## Why
`group` is the *annotation authority*, not a signal that a `-mod` file exists. CGD-authority species can be UniProtKB-only (empty/absent `-mod`), so `group != UniProt` over-emitted broken/empty `-mod` links for **CANO9, CANTT, CLAL4, PICGU**. `mod_id_space` (a **required** field) is the gene-product ID namespace — exactly "has a `-mod` file": `!= UniProtKB` ⇔ a `-mod` file exists.

Verified against the current release: `mod_id_space != UniProtKB` = **exactly** the 17 species with real non-empty `-mod` files — 0 discrepancy both directions (no broken links, none missing). Pure goex, no file cross-check.

## Depends on go-site#2713 (merge first)
#2713 fixes the `mod_id_space` typos/values (`UniProtKBB`, `MGI:MGI`, stray `UniProt`, and the CGD/UniProt calls). Before it lands this key would misfire. After **#2713 + this** merge, run the `update-downloads` workflow (`workflow_dispatch`, #932) to regenerate the committed page.

Refs go-site#2711, go-site#2713, geneontology/pipeline-from-goa#396.

_— Posted by Claude Code agent on behalf of @kltm._
