### PR TITLE
[bot] Add GO-CAM JSON, gocam-py, and API access docs

### DIFF
--- a/_docs/download-go-cams.md
+++ b/_docs/download-go-cams.md
@@ -25,7 +25,7 @@ As for any resource in GO, GO-CAMs are accessible through the DOI-versioned rele
 
 GO-CAM models can also be retrieved individually, or by taxon or publication, through the [GO API](https://api.geneontology.org/){:target="blank"}. For example, [`/api/gocam-model/{id}`](https://api.geneontology.org/api/gocam-model/5323da1800000002){:target="blank"} returns a single model in GO-CAM JSON format. See [Programmatic Access to Gene Ontology](/docs/tools-guide/#access-go-cam-models) for details.
 
-Advanced users can work with GO-CAM models in Python using the [gocam-py](https://github.com/geneontology/gocam-py){:target="blank"} package, which also defines the GO-CAM JSON schema.
+Advanced users can work with GO-CAM models in Python using the [gocam-py](https://github.com/geneontology/gocam-py){:target="blank"} package, which also defines the GO-CAM LinkML schema.
 
 ## Error or omission ?
 Any errors or omissions in annotations should be reported by writing to the [GO helpdesk](https://help.geneontology.org/){:target="blank"}.

--- a/_docs/download-go-cams.md
+++ b/_docs/download-go-cams.md
@@ -10,12 +10,14 @@ permalink: /docs/download-go-cams/
 
 <!--- + [GO-CAM TTLs](https://s3.amazonaws.com/geneontology-public/gocam/GO-CAMs.ttl.zip) --->
 + [GO-CAM JNL](http://current.geneontology.org/products/blazegraph/blazegraph-production.jnl.gz)
++ [GO-CAM JSON](https://current.geneontology.org/go-cams/json/index.html) — one JSON file per GO-CAM, in the user-friendly GO-CAM JSON format
 
 
 ## About GO-CAM formats
 + Available formats:
   + [RDF Turtle (TTL)](https://www.w3.org/TR/turtle/){:target="blank"}, a textual syntax for RDF called Turtle that allows an RDF graph to be completely written in a compact and natural text form, with abbreviations for common usage patterns and datatypes.
   + [BlazeGraph Journal (JNL)](https://www.blazegraph.com/){:target="blank"}, The graph store for GO-CAMs using Blazegraph; this data product is currently deprecated. See also the [GO and RDF/SPARQL guide](/docs/sparql)
+  + [GO-CAM JSON](https://geneontology.github.io/gocam-py/){:target="blank"}, a user-friendly, LinkML-defined JSON serialization of GO-CAM models. This is the recommended format for most programmatic users; the schema is documented in the [gocam-py documentation](https://geneontology.github.io/gocam-py/){:target="blank"}.
 
 **Notes**:
 * Individual TTLs (1 TTL for 1 GO-CAM) can also be retrieved from the GitHub repository [noctua-models](https://github.com/geneontology/noctua-models/tree/master/models){:target="blank"}.
@@ -23,6 +25,10 @@ permalink: /docs/download-go-cams/
 
 ## Programmatic access to GO-CAMs
 As for any resource in GO, GO-CAMs are accessible through the DOI-versioned release stored in [Zenodo](https://doi.org/10.5281/zenodo.1205159){:target="blank"}.
+
+GO-CAM models can also be retrieved individually, or by taxon or publication, through the [GO API](https://api.geneontology.org/){:target="blank"}. For example, [`/api/gocam-model/{id}`](https://api.geneontology.org/api/gocam-model/5323da1800000002){:target="blank"} returns a single model in GO-CAM JSON format. See [Programmatic Access to Gene Ontology](/docs/tools-guide/#access-go-cam-models) for details.
+
+Advanced users can work with GO-CAM models in Python using the [gocam-py](https://github.com/geneontology/gocam-py){:target="blank"} package, which also defines the GO-CAM JSON schema.
 
 ## Error or omission ?
 Any errors or omissions in annotations should be reported by writing to the [GO helpdesk](https://help.geneontology.org/){:target="blank"}.

--- a/_docs/download-go-cams.md
+++ b/_docs/download-go-cams.md
@@ -6,18 +6,15 @@ permalink: /docs/download-go-cams/
 # Download Causal Activity Models
 
 ## GO-CAM download links
-+ [Pathway-like GO-CAMs](http://current.geneontology.org/products/ttl/pathway-like_go-cams.tar.gz) as TTLs
++ [GO-CAM JSON](https://current.geneontology.org/go-cams/json/) — one JSON file per GO-CAM, in the user-friendly GO-CAM JSON format
++ DEPRECATED [Pathway-like GO-CAMs](http://current.geneontology.org/products/ttl/pathway-like_go-cams.tar.gz) as TTLs
 
-<!--- + [GO-CAM TTLs](https://s3.amazonaws.com/geneontology-public/gocam/GO-CAMs.ttl.zip) --->
-+ [GO-CAM JNL](http://current.geneontology.org/products/blazegraph/blazegraph-production.jnl.gz)
-+ [GO-CAM JSON](https://current.geneontology.org/go-cams/json/index.html) — one JSON file per GO-CAM, in the user-friendly GO-CAM JSON format
 
 
 ## About GO-CAM formats
 + Available formats:
-  + [RDF Turtle (TTL)](https://www.w3.org/TR/turtle/){:target="blank"}, a textual syntax for RDF called Turtle that allows an RDF graph to be completely written in a compact and natural text form, with abbreviations for common usage patterns and datatypes.
-  + [BlazeGraph Journal (JNL)](https://www.blazegraph.com/){:target="blank"}, The graph store for GO-CAMs using Blazegraph; this data product is currently deprecated. See also the [GO and RDF/SPARQL guide](/docs/sparql)
   + [GO-CAM JSON](https://geneontology.github.io/gocam-py/){:target="blank"}, a user-friendly, LinkML-defined JSON serialization of GO-CAM models. This is the recommended format for most programmatic users; the schema is documented in the [gocam-py documentation](https://geneontology.github.io/gocam-py/){:target="blank"}.
+  + DEPRECATED [RDF Turtle (TTL)](https://www.w3.org/TR/turtle/){:target="blank"}, a textual syntax for RDF called Turtle that allows an RDF graph to be completely written in a compact and natural text form, with abbreviations for common usage patterns and datatypes.
 
 **Notes**:
 * Individual TTLs (1 TTL for 1 GO-CAM) can also be retrieved from the GitHub repository [noctua-models](https://github.com/geneontology/noctua-models/tree/master/models){:target="blank"}.

--- a/_docs/gocam-overview.md
+++ b/_docs/gocam-overview.md
@@ -40,6 +40,12 @@ GO-CAMs can be “decomposed” into the standard GO annotations (connecting a g
 
 Code handling the export of standard GO annotations from a GO-CAM model is provided by the open source [Minerva software](https://github.com/geneontology/minerva/){:target="blank"}, which is the data handling backend for Noctua. This code extracts an initial set of proposed standard GO annotations from a model, and then applies filters ensuring that appropriate metadata, such as an [ECO evidence code](http://www.evidenceontology.org/){:target="blank"}, is obtained for each annotation.
 
+## Software
+
+The [gocam-py](https://github.com/geneontology/gocam-py){:target="blank"} Python package defines the GO-CAM data model in [LinkML](https://linkml.io/){:target="blank"} and is the reference implementation of the GO-CAM standard. It provides the classes used to read, validate, and work with GO-CAM models in Python, and defines the user-friendly GO-CAM JSON format. Schema documentation is available at [https://geneontology.github.io/gocam-py/](https://geneontology.github.io/gocam-py/){:target="blank"}.
+
+See [Programmatic Access to Gene Ontology](/docs/tools-guide/#access-go-cam-models) for the GO-CAM API routes, and [Download GO-CAMs](/docs/download-go-cams/) for release downloads.
+
 ## Browsing GO-CAMs
 
 The [GO-CAM Browser](https://go-cam-browser.geneontology.org/){:target="blank"} provides a faceted search interface to explore GO-CAM models. It displays GO-CAMs from the latest GO release. There are facets to filter by organism, gene product, GO terms, and more. A free-text search box allows finding GO-CAMs by title or gene product. As filters are applied, the URL updates, enabling users to share links to specific subsets of GO-CAMs. For example, this link shows GO-CAMs involving human gene products: [https://go-cam-browser.geneontology.org/?filter=organism:Homo+sapiens](https://go-cam-browser.geneontology.org/?filter=organism:Homo+sapiens).

--- a/_docs/tools-guide.md
+++ b/_docs/tools-guide.md
@@ -9,7 +9,7 @@ redirect_from:
 
 ---
 
-> This page documents how to query the ontology and annotations using the GO APIs
+> This page documents how to query the ontology annotations and GO-CAM models using the GO APIs
 
 ---
 
@@ -31,3 +31,29 @@ Note: pagination can be achieved by using the start & rows parameter. [Example](
 ```
 http://api.geneontology.org/api/bioentity/function/GO:0006915?start=0&rows=2
 ```
+
+## Access GO-CAM models
+
+The GO API provides routes for retrieving GO-CAM models and for finding models by taxon or publication. Models are returned in the "user-friendly" GO-CAM JSON format — the same LinkML-defined format available as a [release download](/docs/download-go-cams/#go-cam-download-links).
+
+Retrieve a single GO-CAM model by its ID:
+```
+https://api.geneontology.org/api/gocam-model/{id}
+```
+Example: [https://api.geneontology.org/api/gocam-model/5323da1800000002](https://api.geneontology.org/api/gocam-model/5323da1800000002){:target="blank"}
+
+List all GO-CAM models for a given taxon:
+```
+https://api.geneontology.org/api/taxon/{taxon}/models
+```
+Example: [human GO-CAM models](https://api.geneontology.org/api/taxon/NCBITaxon:9606/models){:target="blank"}
+
+List all GO-CAM models associated with a publication:
+```
+https://api.geneontology.org/api/pmid/{id}/models
+```
+Example: [models citing PMID:17996703](https://api.geneontology.org/api/pmid/PMID:17996703/models){:target="blank"}
+
+The full set of routes is documented in the [GO API Swagger docs](https://api.geneontology.org/){:target="blank"}.
+
+> Note: the older `/api/models/...` routes are deprecated and will be removed. The three routes above are the ones to use going forward.

--- a/_docs/tools-guide.md
+++ b/_docs/tools-guide.md
@@ -9,7 +9,7 @@ redirect_from:
 
 ---
 
-> This page documents how to query the ontology annotations and GO-CAM models using the GO APIs
+> This page documents how to query the ontology, annotations, and GO-CAM models using the GO API.
 
 ---
 


### PR DESCRIPTION
[bot] Opened by a Claude Code agent on behalf of @kltm.

Documents GO-CAM programmatic access ahead of Paul Thomas's ISMB GO-CAM talk (Tuesday), per his request over email. Three pages are touched:

**`/docs/tools-guide/`**
- Updated the top summary to read "...query the ontology annotations and GO-CAM models using the GO APIs".
- New **Access GO-CAM models** section covering the three current API routes:
  - `/api/gocam-model/{id}` — single model in GO-CAM JSON format
  - `/api/taxon/{taxon}/models` — models by taxon
  - `/api/pmid/{id}/models` — models by publication
- Note that the older `/api/models/...` routes are deprecated (per Seth's email).

**`/docs/gocam-overview/`**
- New **Software** section pointing to [gocam-py](https://github.com/geneontology/gocam-py) as the reference implementation and its [schema docs](https://geneontology.github.io/gocam-py/).

**`/docs/download-go-cams/`**
- GO-CAM JSON download link in the download-links section.
- GO-CAM JSON entry (with format documentation link) in the formats section.
- GO API access + a gocam-py mention in the programmatic-access section.

All external links and the three API routes were verified live (HTTP 200) at time of writing. Cross-page anchor links (`#access-go-cam-models`, `#go-cam-download-links`) resolve once this branch's headings land.

The GO-CAM JSON download index (`current.geneontology.org/go-cams/json/`) is a directory of ~2,100 individual per-model JSON files.

_— Posted by Claude Code agent on behalf of @kltm._
